### PR TITLE
fix: resolve Frappe Cloud marketplace Semgrep findings

### DIFF
--- a/docs-site/gen_api.py
+++ b/docs-site/gen_api.py
@@ -123,7 +123,7 @@ def collect():
     modules = []
     for mod, folder, note in MODULES:
         path = os.path.join(APP, f"{mod}.py")
-        tree = ast.parse(open(path).read())
+        tree = ast.parse(open(path).read())  # nosemgrep: frappe-security-file-traversal -- path is derived from the app source tree, not from user input
         eps = []
         for node in tree.body:
             if not isinstance(node, ast.FunctionDef):
@@ -200,7 +200,7 @@ Content-Type: application/json
                     out.append(f"| `{n}` | {'yes' if req else 'no'} | "
                                f"{'' if d in (None,) else f'`{d}`'} |")
                 out.append("")
-    open(os.path.join(HERE, "api-reference.md"), "w").write("\n".join(out))
+    open(os.path.join(HERE, "api-reference.md"), "w").write("\n".join(out))  # nosemgrep: frappe-security-file-traversal -- path is derived from the app source tree, not from user input
     return total
 
 
@@ -258,7 +258,7 @@ def write_postman(modules):
         "item": items,
     }
     path = os.path.join(HERE, "public", "kamra.postman_collection.json")
-    open(path, "w").write(json.dumps(collection, indent=1))
+    open(path, "w").write(json.dumps(collection, indent=1))  # nosemgrep: frappe-security-file-traversal -- path is derived from the app source tree, not from user input
 
 
 if __name__ == "__main__":

--- a/kamra/agents_api.py
+++ b/kamra/agents_api.py
@@ -29,7 +29,7 @@ def activity_feed(property: str | None = None, actor_kind: str | None = None,
 		conds.append("action_type = %(action_type)s")
 		params["action_type"] = action_type
 	where = ("WHERE " + " AND ".join(conds)) if conds else ""
-	return frappe.db.sql(f"""
+	return frappe.db.sql(f"""  # nosemgrep: frappe-sql-format-injection -- values are parameterized; interpolated text is a constant or whitelisted identifier, not user input
 		SELECT name, creation, actor, agent_name, action_type, action_channel,
 		       approval_status, autonomy, approver, reference_doctype,
 		       reference_name, rationale, minutes_saved, executed_at

--- a/kamra/agents_channels.py
+++ b/kamra/agents_channels.py
@@ -77,7 +77,7 @@ def voice_webhook(payload: str | dict | None = None) -> dict:
 		channel="Voice",
 		approval_status="Executed",
 	)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 
 	return {
 		"ok": True,
@@ -126,7 +126,7 @@ def messaging_webhook(payload: str | dict | None = None) -> dict:
 		channel="WhatsApp",
 		approval_status="Executed",
 	)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 
 	return {
 		"ok": True,

--- a/kamra/allocation.py
+++ b/kamra/allocation.py
@@ -130,7 +130,7 @@ def suggest_allocation(property: str, date: str | None = None):
 
 		g = gmeta.get(a.guest)
 		vip = bool(g and g.vip)
-		prefs = " ".join(filter(None, [a.special_requests,
+		prefs = " ".join(filter(None, [a.special_requests,  # nosemgrep: frappe-no-functional-code -- filter(None, ...) drops empty parts; equivalent to a comprehension
 		                               g.guest_notes if g else None]))
 		# high/low floor is relative to the rooms actually on offer for this type
 		cfloors = [_as_int(r.get("floor")) for r in cands
@@ -186,5 +186,5 @@ def apply_allocation(property: str, assignments):
 		           rationale=f"→ room {room}. {a.get('why') or ''}".strip())
 		executed.append({"reservation": res, "room": room})
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"executed": executed}

--- a/kamra/api.py
+++ b/kamra/api.py
@@ -60,7 +60,7 @@ def generate_api_key():
 		doc.api_key = frappe.generate_hash(length=15)
 	doc.api_secret = api_secret
 	doc.save(ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"api_key": doc.api_key, "api_secret": api_secret}
 
 
@@ -385,7 +385,7 @@ def registration_card(reservation: str):
 		"property": {
 			"property_name": prop.property_name,
 			"logo_url": prop.get("logo_url"),
-			"address": ", ".join(filter(None, [
+			"address": ", ".join(filter(None, [  # nosemgrep: frappe-no-functional-code -- filter(None, ...) drops empty address parts; equivalent to a comprehension
 				prop.address_line, prop.city, prop.state, prop.pincode])),
 			"gstin": prop.gstin, "phone": prop.phone, "email": prop.email,
 			"checkin_time": str(prop.checkin_time or ""),
@@ -417,7 +417,7 @@ def registration_card(reservation: str):
 			"id_file": guest.get("id_file"),
 			"address_proof_file": guest.get("address_proof_file"),
 			"guest_id": guest.name,
-			"address": ", ".join(filter(None, [
+			"address": ", ".join(filter(None, [  # nosemgrep: frappe-no-functional-code -- filter(None, ...) drops empty address parts; equivalent to a comprehension
 				guest.get("address_line"), guest.get("city")])),
 		},
 		"occupants": [
@@ -1255,7 +1255,7 @@ def folio_invoice(folio: str):
 			"logo_url": prop.get("logo_url"),
 			"address_line": prop.address_line, "city": prop.city,
 			"state": prop.state, "pincode": prop.pincode,
-			"address": ", ".join(filter(None, [prop.address_line, prop.city,
+			"address": ", ".join(filter(None, [prop.address_line, prop.city,  # nosemgrep: frappe-no-functional-code -- filter(None, ...) drops empty address parts; equivalent to a comprehension
 			                                   prop.state, prop.pincode])),
 			"gstin": prop.gstin, "phone": prop.phone, "email": prop.email,
 			# country pack owns the service code + place-of-supply rule
@@ -1323,7 +1323,7 @@ def guests_with_stats(search: str | None = None):
 	if search:
 		where = "WHERE g.full_name LIKE %(q)s OR g.phone LIKE %(q)s"
 		params["q"] = f"%{search}%"
-	return frappe.db.sql(
+	return frappe.db.sql(  # nosemgrep: frappe-sql-format-injection -- values are parameterized; interpolated text is a constant or whitelisted identifier, not user input
 		f"""
 		SELECT
 			g.name, g.full_name, g.phone, g.email, g.vip,
@@ -1395,7 +1395,7 @@ def merge_guests(source: str, target: str):
 			moved[doctype] = len(rows)
 	# denormalized guest_name on stays and bills follows the survivor
 	for doctype in ("Reservation", "Folio"):
-		frappe.db.sql(
+		frappe.db.sql(  # nosemgrep: frappe-sql-format-injection -- values are parameterized; interpolated text is a constant or whitelisted identifier, not user input
 			f"UPDATE `tab{doctype}` SET guest_name = %s WHERE guest = %s",
 			(dst.full_name, target))
 
@@ -1434,7 +1434,7 @@ def anonymize_guest(guest: str):
 	})
 	doc.save(ignore_permissions=True)
 	for doctype in ("Reservation", "Folio"):
-		frappe.db.sql(
+		frappe.db.sql(  # nosemgrep: frappe-sql-format-injection -- values are parameterized; interpolated text is a constant or whitelisted identifier, not user input
 			f"UPDATE `tab{doctype}` SET guest_name = %s WHERE guest = %s",
 			(alias, guest))
 	# the stay register keeps masked IDs only
@@ -1551,7 +1551,7 @@ def guest_journey(guest: str):
 			"id_number": doc.id_number,
 			"blacklisted": doc.get("blacklisted"),
 			"blacklist_reason": doc.get("blacklist_reason"),
-			"address": ", ".join(filter(None, [
+			"address": ", ".join(filter(None, [  # nosemgrep: frappe-no-functional-code -- filter(None, ...) drops empty address parts; equivalent to a comprehension
 				doc.get("address_line"), doc.get("city")])),
 			"notes": doc.guest_notes,
 		},
@@ -2201,7 +2201,7 @@ def cancellation_letter(reservation: str):
 		"property": {
 			"property_name": prop.property_name,
 			"logo_url": prop.get("logo_url"),
-			"address": ", ".join(filter(None, [
+			"address": ", ".join(filter(None, [  # nosemgrep: frappe-no-functional-code -- filter(None, ...) drops empty address parts; equivalent to a comprehension
 				prop.address_line, prop.city, prop.state, prop.pincode])),
 			"phone": prop.phone, "email": prop.email,
 		},
@@ -2453,7 +2453,7 @@ def send_precheckin_link(reservation: str, channel: str = "WhatsApp"):
 	log_action("send_precheckin_link", "Reservation", reservation, res.property,
 	           minutes_saved=2,
 	           rationale=f"Self check-in link {'sent via ' + channel if sent else 'generated'}")
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True, "link": link, "sent": sent,
 	        "channel": channel if sent else None}
 
@@ -2470,7 +2470,7 @@ def set_stay_times(reservation: str, eta: str | None = None,
 		"planned_check_in_time": eta or None,
 		"planned_check_out_time": etd or None,
 	})
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True}
 
 
@@ -3225,7 +3225,7 @@ def set_cashier_pin(pin: str, current_pin: str | None = None):
 	else:
 		frappe.get_doc({"doctype": "Cashier PIN", "user": user,
 		                "pin": pin}).insert(ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True}
 
 
@@ -3304,7 +3304,7 @@ def save_group_blocks(group_booking: str, blocks, cutoff_date: str | None = None
 	if status:
 		gb.status = status
 	gb.save(ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True, "blocks": len(gb.blocks)}
 
 
@@ -3385,7 +3385,7 @@ def create_group_block(property: str, group_name: str, check_in_date: str,
 		gb.event = ev.name
 		gb.save(ignore_permissions=True)
 		event = ev.name
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	from kamra.savings import log_action
 	log_action("group_block_drafted", "Group Booking", gb.name, property,
 	           minutes_saved=15,
@@ -3414,7 +3414,7 @@ def my_connector_credentials(property: str):
 	u.api_key = api_key
 	u.api_secret = api_secret
 	u.save(ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	from kamra.savings import log_action
 	log_action("connector_key_issued", "User", user,
 	           rationale="Personal MCP connector credentials (re)generated")

--- a/kamra/assistant.py
+++ b/kamra/assistant.py
@@ -644,7 +644,7 @@ def create_conversation(property: str, title: str = "New chat"):
 	doc.title = title or "New chat"
 	doc.messages = "[]"
 	doc.insert(ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"name": doc.name, "title": doc.title}
 
 
@@ -658,7 +658,7 @@ def save_conversation(name: str, messages, title: str | None = None):
 	if title:
 		updates["title"] = title[:140]
 	frappe.db.set_value("Copilot Conversation", name, updates)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True}
 
 
@@ -668,7 +668,7 @@ def rename_conversation(name: str, title: str):
 	_own_convo(name)
 	frappe.db.set_value("Copilot Conversation", name, "title",
 	                    (title or "Untitled")[:140])
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True}
 
 
@@ -677,5 +677,5 @@ def rename_conversation(name: str, title: str):
 def delete_conversation(name: str):
 	_own_convo(name)
 	frappe.delete_doc("Copilot Conversation", name, ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True}

--- a/kamra/channels/channex.py
+++ b/kamra/channels/channex.py
@@ -89,7 +89,7 @@ def parse_webhook(conn, payload) -> list[dict]:
 			"check_out": room.get("checkout_date") or body.get("departure_date"),
 			"adults": int(occ.get("adults") or 2),
 			"children": int(occ.get("children") or 0),
-			"guest_name": " ".join(filter(None, [customer.get("name"),
+			"guest_name": " ".join(filter(None, [customer.get("name"),  # nosemgrep: frappe-no-functional-code -- filter(None, ...) drops empty parts; equivalent to a comprehension
 			                                     customer.get("surname")]))
 			              or "OTA Guest",
 			"phone": customer.get("phone") or "",

--- a/kamra/folio.py
+++ b/kamra/folio.py
@@ -728,7 +728,7 @@ def run_night_audit(property: str, business_date: str | None = None) -> dict:
 		autonomy="Full",
 		channel="API",
 	)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {
 		"audit": audit.name,
 		"room_charges_posted": charges_posted,

--- a/kamra/inventory.py
+++ b/kamra/inventory.py
@@ -573,7 +573,7 @@ def wastage_report(property: str, outlet: str | None = None, days: int = 30):
 	if outlet:
 		conds.append("p.outlet = %(outlet)s")
 		params["outlet"] = outlet
-	lines = frappe.db.sql(f"""
+	lines = frappe.db.sql(f"""  # nosemgrep: frappe-sql-format-injection -- values are parameterized; interpolated text is a constant or whitelisted identifier, not user input
 		select i.item_name, i.menu_item, i.qty, i.void_reason, p.outlet,
 		       p.name as order_name, p.creation
 		  from `tabPOS Order Item` i

--- a/kamra/marketplace.py
+++ b/kamra/marketplace.py
@@ -238,7 +238,7 @@ def connect_heykoala(property: str, channel: str, phone_number: str):
 	doc.active = 1
 	doc.webhook_secret = secret
 	doc.save(ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 
 	from kamra.savings import log_action
 	log_action("channel_connected", "Channel Provider Connection", doc.name,
@@ -262,7 +262,7 @@ def connect_heykoala(property: str, channel: str, phone_number: str):
 @require_roles("Hotel Admin", "System Manager")
 def disconnect_channel(connection: str):
 	frappe.db.set_value("Channel Provider Connection", connection, "active", 0)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True}
 
 

--- a/kamra/menu_import.py
+++ b/kamra/menu_import.py
@@ -248,7 +248,7 @@ def run_menu_import(property: str, csv_text: str, outlet: str | None = None,
 		except Exception as e:
 			errors.append({"row": r["row"], "item": r["item_name"],
 			               "error": str(e)[:160]})
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 
 	from kamra.savings import log_action
 	log_action(

--- a/kamra/migrate.py
+++ b/kamra/migrate.py
@@ -107,7 +107,7 @@ def _parse_date(v: str, dayfirst: bool):
 		return None
 	m = re.match(r"^(\d{4})-(\d{1,2})-(\d{1,2})$", v)
 	if m:
-		y, mo, d = map(int, m.groups())
+		y, mo, d = (int(x) for x in m.groups())
 		return f"{y:04d}-{mo:02d}-{d:02d}"
 	m = re.match(r"^(\d{1,2})[/.-](\d{1,2})[/.-](\d{2,4})$", v)
 	if m:

--- a/kamra/patches/v23/backfill_action_log_approval_status.py
+++ b/kamra/patches/v23/backfill_action_log_approval_status.py
@@ -22,4 +22,4 @@ def execute():
 		WHERE approval_status IS NULL OR approval_status = ''
 		"""
 	)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- migration patch runs outside the request cycle; explicit commit persists the backfill

--- a/kamra/payments.py
+++ b/kamra/payments.py
@@ -112,5 +112,5 @@ def razorpay_webhook():
 		           minutes_saved=3,
 		           rationale=f"₹{amount:,.0f} auto-posted from payment link",
 		           agent_name="Payments", channel="API")
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True, "folio": folio.name, "posted": not already}

--- a/kamra/public_api.py
+++ b/kamra/public_api.py
@@ -316,7 +316,7 @@ def precheckin_submit(token: str, id_type: str, id_number: str,
 		agent_name="Self Check-in",
 		channel="API",
 	)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True, "reservation": res.name}
 
 
@@ -364,7 +364,7 @@ def precheckin_upload_id(token: str, data: str):
 		agent_name="Self Check-in",
 		channel="API",
 	)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True}
 
 
@@ -447,7 +447,7 @@ def request_guest_laundry(token: str, notes: str = "", express: int = 0):
 		agent_name="Guest Self-Service",
 		channel="API",
 	)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True, "order": doc.name}
 
 
@@ -532,7 +532,7 @@ def book(property: str, room_type: str, check_in_date: str,
 		frappe.db.set_value("Reservation", result["reservation"], updates)
 		if email:
 			frappe.db.set_value("Guest", result["guest"], "email", email)
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	finally:
 		frappe.set_user("Guest")
 
@@ -604,7 +604,7 @@ def qr_order(outlet: str, items, room: str | None = None,
 	try:
 		out = pos.create_order(outlet=outlet, items=items, room=room or None,
 		                       table_no=table_no or None, source="QR")
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	finally:
 		frappe.set_user("Guest")
 	return {"ok": True, "order": out["order"], "order_total": out["order_total"],
@@ -638,7 +638,7 @@ def hosting_enquiry(full_name: str, email: str, phone: str = "",
 		"status": "New",
 	})
 	doc.insert(ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	try:
 		frappe.sendmail(
 			recipients=["hello@kamrapms.com"],

--- a/kamra/realtime.py
+++ b/kamra/realtime.py
@@ -14,7 +14,7 @@ def notify(doc, method=None):
 	if doc.doctype not in WATCHED:
 		return
 	try:
-		frappe.publish_realtime(
+		frappe.publish_realtime(  # nosemgrep: frappe-realtime-pick-room -- intentional lightweight property-wide change ping; clients filter by property and re-fetch
 			"kamra_changed",
 			{"doctype": doc.doctype,
 			 "property": doc.get("property")},

--- a/kamra/reports.py
+++ b/kamra/reports.py
@@ -214,7 +214,7 @@ def save_budget(property: str, period: str, room_revenue_target: float = 0,
 		"adr_target": adr_target, "revpar_target": revpar_target,
 	})
 	doc.save(ignore_permissions=True)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- persists the completed operation before returning to an external/public caller; reviewed as intentional
 	return {"ok": True}
 
 
@@ -226,7 +226,7 @@ def contribution(property: str, from_date: str, to_date: str,
 	booking source, company or travel agent. by = source | company | travel_agent."""
 	col = {"source": "r.source", "company": "r.company",
 	       "travel_agent": "r.travel_agent"}.get(by, "r.source")
-	rows = frappe.db.sql(
+	rows = frappe.db.sql(  # nosemgrep: frappe-sql-format-injection -- values are parameterized; interpolated text is a constant or whitelisted identifier, not user input
 		f"""
 		SELECT COALESCE({col}, 'Direct') AS label,
 		       COUNT(*) AS bookings,

--- a/kamra/scripts/bootstrap_schema.py
+++ b/kamra/scripts/bootstrap_schema.py
@@ -256,5 +256,5 @@ def execute():
     ], naming_rule="Expression", autoname="format:AAL-{YYYY}-{######}",
        extra={"in_create": 0})
 
-    frappe.db.commit()
+    frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
     print("Kamra v0 schema bootstrapped.")

--- a/kamra/scripts/bootstrap_v1.py
+++ b/kamra/scripts/bootstrap_v1.py
@@ -106,7 +106,7 @@ def execute():
 	# ── New booking fields on Reservation ────────────────────────────────
 	add_reservation_fields()
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Kamra v1 schema (meal plans, seasons, vouchers, groups, corporate) ready.")
 
 

--- a/kamra/scripts/bootstrap_v10.py
+++ b/kamra/scripts/bootstrap_v10.py
@@ -95,5 +95,5 @@ def execute():
 		_grant(doctype, "Revenue Manager", 1, 1, 1)
 		_grant(doctype, "Housekeeping", 1, 0, 0)
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Kamra v10 schema (POS + experiences) ready.")

--- a/kamra/scripts/bootstrap_v2.py
+++ b/kamra/scripts/bootstrap_v2.py
@@ -118,5 +118,5 @@ def execute():
 		f("log", "Small Text", read_only=1),
 	], naming_rule="Expression", autoname="format:AUDIT-{business_date}")
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Kamra v2 schema (folio, night audit) ready.")

--- a/kamra/scripts/bootstrap_v3.py
+++ b/kamra/scripts/bootstrap_v3.py
@@ -64,5 +64,5 @@ def execute():
 			}).insert(ignore_permissions=True)
 			print(f"granted {role} perms on Service Ticket")
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Kamra v3 schema (service tickets) ready.")

--- a/kamra/scripts/bootstrap_v4.py
+++ b/kamra/scripts/bootstrap_v4.py
@@ -36,5 +36,5 @@ def execute():
 		_grant("Rate Guardrail", role, r, w, c, delete=d)
 	print("Rate Guardrail perms granted")
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Kamra v4 schema (rate guardrails) ready.")

--- a/kamra/scripts/bootstrap_v5.py
+++ b/kamra/scripts/bootstrap_v5.py
@@ -92,5 +92,5 @@ def execute():
 		except Exception:
 			pass
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Kamra v5 schema ready.")

--- a/kamra/scripts/bootstrap_v6.py
+++ b/kamra/scripts/bootstrap_v6.py
@@ -53,5 +53,5 @@ def execute():
 		     description="Comma-separated, e.g. Pool, Parking, Restaurant"),
 	])
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Kamra v6 schema (booking engine) ready.")

--- a/kamra/scripts/bootstrap_v7.py
+++ b/kamra/scripts/bootstrap_v7.py
@@ -47,5 +47,5 @@ def execute():
 		)
 	print("tokens backfilled")
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Kamra v7 schema (self check-in) ready.")

--- a/kamra/scripts/bootstrap_v8.py
+++ b/kamra/scripts/bootstrap_v8.py
@@ -183,5 +183,5 @@ def execute():
 			_grant(doctype, role, r, w, c, delete=1 if role in ("System Manager", "Hotel Admin") else 0)
 	print("perms granted for v8 doctypes")
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Kamra v8 schema (eZee parity long tail) ready.")

--- a/kamra/scripts/bootstrap_v9.py
+++ b/kamra/scripts/bootstrap_v9.py
@@ -43,5 +43,5 @@ def execute():
 		     label="Payment Link ID", insert_after="payment_link_url"),
 	])
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Kamra v9 schema (payments) ready.")

--- a/kamra/scripts/eval_harness.py
+++ b/kamra/scripts/eval_harness.py
@@ -2069,7 +2069,7 @@ def t47():
 
 @check("WhatsApp: native Meta send, booking flow, inbound -> ticket")
 def t48():
-	from kamra import whatsapp
+	from kamra import whatsapp  # nosemgrep: frappe-monkey-patching-not-allowed -- offline eval harness stubs the outbound transport for tests; not a production code path
 	from kamra.agents_channels import send_outbound
 
 	# a connection with our own number - fake creds, intercepted transport
@@ -2296,7 +2296,7 @@ def t53():
 	from frappe.utils import add_days, nowdate
 
 	from kamra import channel_manager as cm
-	from kamra.channels import channex
+	from kamra.channels import channex  # nosemgrep: frappe-monkey-patching-not-allowed -- offline eval harness stubs the outbound transport for tests; not a production code path
 
 	conn = frappe.get_doc({
 		"doctype": "Channel Manager Connection", "property": P,

--- a/kamra/scripts/fix_perms_fields.py
+++ b/kamra/scripts/fix_perms_fields.py
@@ -183,5 +183,5 @@ def execute():
 	fix_permissions()
 	sync_standard_perms()
 	frappe.clear_cache()
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Fixed. Reload the UI.")

--- a/kamra/scripts/loc_parity.py
+++ b/kamra/scripts/loc_parity.py
@@ -35,12 +35,12 @@ def _snapshot():
 
 
 def capture():
-	json.dump(_snapshot(), open(BASELINE, "w"), sort_keys=True, indent=2)
+	json.dump(_snapshot(), open(BASELINE, "w"), sort_keys=True, indent=2)  # nosemgrep: frappe-security-file-traversal -- path is derived from the app source tree, not from user input
 	print("BASELINE written")
 
 
 def compare():
-	before = json.load(open(BASELINE))
+	before = json.load(open(BASELINE))  # nosemgrep: frappe-security-file-traversal -- path is derived from the app source tree, not from user input
 	after = _snapshot()
 	bj = json.dumps(before, sort_keys=True)
 	aj = json.dumps(after, sort_keys=True)

--- a/kamra/scripts/seed_demo.py
+++ b/kamra/scripts/seed_demo.py
@@ -42,7 +42,7 @@ def execute():
 		ensure_users()  # keep login accounts present even on re-run
 		from kamra.scripts.seed_showcase import execute as seed_showcase
 		seed_showcase()  # top up experiences/venues (idempotent)
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 		print("Demo property already exists — ensured demo users + showcase.")
 		return
 
@@ -206,5 +206,5 @@ def execute():
 	from kamra.scripts.seed_showcase import execute as seed_showcase
 	seed_showcase()
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print(f"Seeded demo property '{PROPERTY}' with rooms, guests, reservations and login users.")

--- a/kamra/scripts/seed_property2.py
+++ b/kamra/scripts/seed_property2.py
@@ -68,5 +68,5 @@ def execute():
 		}).insert(ignore_permissions=True)
 		print("frontdesk@kamra.local restricted to Kamra Demo Palace")
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Portfolio demo ready.")

--- a/kamra/scripts/seed_rbac_v2.py
+++ b/kamra/scripts/seed_rbac_v2.py
@@ -86,5 +86,5 @@ def execute():
 	ensure_hotel_admin()
 	ensure_agent_user()
 	frappe.clear_cache()
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("RBAC v2 ready.")

--- a/kamra/scripts/seed_showcase.py
+++ b/kamra/scripts/seed_showcase.py
@@ -386,7 +386,7 @@ def execute():
 
 	extra = seed_sample_content()
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print(f"Showcase seed: +{added_exp} experiences, +{added_venue} venues, "
 	      f"+{added_outlet} outlets, +{added_item} menu items, "
 	      f"+{added_rate} laundry rates, +{added_ticket} tickets, "

--- a/kamra/scripts/seed_users.py
+++ b/kamra/scripts/seed_users.py
@@ -146,5 +146,5 @@ def ensure_users():
 def execute():
 	ensure_roles()
 	ensure_users()
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("Roles and demo users ready.")

--- a/kamra/scripts/seed_v1.py
+++ b/kamra/scripts/seed_v1.py
@@ -57,5 +57,5 @@ def execute():
 	       {"gstin": "29AAViCR1234A1Z1", "contact_name": "Priya Nair",
 	        "contact_email": "travel@rock8.ai", "credit_allowed": 1})
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("v1 demo data ready.")

--- a/kamra/scripts/seed_v6.py
+++ b/kamra/scripts/seed_v6.py
@@ -51,5 +51,5 @@ def execute():
 		rt.save(ignore_permissions=True)
 		print(f"media added: {code}")
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- batch/seed/migration script runs outside the request cycle; explicit commit persists the staged writes
 	print("v6 showcase seed done.")

--- a/kamra/www/kamra.py
+++ b/kamra/www/kamra.py
@@ -25,7 +25,7 @@ def get_context(context):
 			title="Kamra not built",
 		)
 
-	with open(index_path, encoding="utf-8") as f:
+	with open(index_path, encoding="utf-8") as f:  # nosemgrep: frappe-security-file-traversal -- serves the app's own built index.html from a fixed app path, not user input
 		html = f.read()
 
 	csrf = frappe.sessions.get_csrf_token()


### PR DESCRIPTION
Clears the Semgrep findings from the Frappe Cloud marketplace app review.

**Approach:** the flagged rules are false positives, intentional design, or advisory style. Per Frappe's own rule messages, the sanctioned resolution is an inline `# nosemgrep` with a justifying comment. One trivial `map()` was rewritten as a generator.

| Rule | Count | Resolution |
|---|---|---|
| frappe-manual-commit | 47 | seed/bootstrap/migration/patch scripts (outside request cycle) + public endpoints that persist before returning |
| frappe-sql-format-injection | 6 | false positives — values parameterized; only constants/whitelisted identifiers interpolated |
| frappe-security-file-traversal | 6 | paths from the app source tree / fixed app path, not user input |
| frappe-monkey-patching | 2 | offline eval harness stubs transports for tests |
| frappe-realtime-pick-room | 1 | intentional property-wide change ping |
| frappe-no-functional-code | 8 | annotated address-joins; rewrote one map() |

All touched files verified to parse (`py_compile` + `compileall`). A full grep sweep of the deterministic patterns (commits, filter/map, sql f-strings, open()) confirmed no other instances remain — including one hidden `frappe.db.commit()` in a patch file that the pasted report omitted.

Rides the next train into a patch release for FC to re-scan `main`.