### PR TITLE
chore: unblock Frappe Cloud marketplace review

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,36 @@
+# Mandatory for Frappe Cloud Marketplace review.
+# Mirrors https://github.com/frappe/semgrep-rules#how-to-use-in-my-app
+name: Linters
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linter:
+    name: Semgrep Rules
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Download Semgrep rules
+        run: git clone --depth 1 https://github.com/frappe/semgrep-rules.git frappe-semgrep-rules
+
+      - name: Run Semgrep rules
+        # ERROR-severity only: Frappe's own tip. WARNING rules (translations,
+        # guest whitelist, type hints) are reviewed by hand on the marketplace
+        # audit; failing CI on 200+ style warnings would hide a real ERROR.
+        run: |
+          pip install semgrep
+          semgrep --error --severity=ERROR \
+            --config ./frappe-semgrep-rules/rules \
+            --config r/python.lang.correctness

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -75,9 +75,12 @@ The maintainer runbook. Contributors don't need this — see
       marketplace benches don't run npm)
 - [x] Root `package.json` build script for Frappe Cloud
 - [x] README compatibility table (Kamra `main` releases ↔ Frappe v16)
-- [ ] Publisher account on frappecloud.com + listing (title, description,
-      screenshots from `docs/screenshots/`, category "Hospitality"), then
-      create a marketplace release from `main` and submit for review
+- [x] Publisher account on frappecloud.com; Marketplace App `kamra` exists
+      (public page is Draft / **Not Available** until a release is approved)
+- [ ] Listing copy, Hospitality category, logo, screenshots, Support +
+      Privacy URLs — paste from [`docs/marketplace-listing.md`](docs/marketplace-listing.md)
+- [ ] Publish the `main` / v2.5.0 release for review; if Draft > 10 days,
+      ticket https://support.frappe.io/ (template in the listing doc)
 
 ## Secrets the pipelines need (repo → Settings → Secrets)
 

--- a/docs-site/self-hosting/frappe-cloud.md
+++ b/docs-site/self-hosting/frappe-cloud.md
@@ -12,7 +12,6 @@ backups and updates handled for you.
 Billing for the server goes to Frappe Cloud; Kamra itself is free there
 too — same code, every feature.
 
-::: tip
-If you'd rather have the Kamra team run it (including migration from
-your current PMS), that's [Kamra Cloud](https://kamrapms.com/#cloud).
-:::
+The same AGPL code runs here; Frappe Cloud handles the bench, backups
+and updates. For a walkthrough of the product after install, use the
+[live demo](https://demo.kamrapms.com).

--- a/docs/marketplace-listing.md
+++ b/docs/marketplace-listing.md
@@ -1,14 +1,21 @@
 # Frappe Cloud Marketplace listing — Kamra
 
-Paste-ready copy for the Frappe Cloud publisher form (frappecloud.com →
-Marketplace → Kamra). Fill each field from the matching section below.
-Keep this file in sync with the README when the feature set changes.
+Paste-ready copy for the Frappe Cloud publisher form
+(frappecloud.com → Marketplace → Kamra). Keep this file in sync with the
+README when the feature set changes.
+
+Copy follows the [marketplace guidelines](https://docs.frappe.io/cloud/marketplace/marketplace-guidelines)
+and [app authoring guidelines](https://docs.frappe.io/cloud/marketplace/app-authoring-guidelines):
+short description 40–80 characters, no install steps, no persuasion away
+from Frappe Cloud.
 
 - **Repo / branch to build from:** `Kamra-PMS/kamra-pms`, branch `main`
 - **Frappe version:** v16
 - **Pricing:** Free
 - **License:** AGPL-3.0
-- **Category:** Hospitality (or nearest — "Other" if Hospitality is absent)
+- **Category:** Hospitality (use **Other** if Hospitality is absent — do
+  **not** leave it on E-Commerce)
+- **Public listing (currently Not Available):** https://frappecloud.com/marketplace/apps/kamra
 
 ---
 
@@ -20,100 +27,109 @@ Kamra — Hotel & Short-Term Rental PMS
 
 ## Short description (one line / summary field)
 
+40–80 characters, one sentence, do not repeat the app name.
+
 ```
-The open-source, agent-ready PMS for hotels and short-term rentals — front desk, villa catalogs, direct booking, POS, housekeeping, folios and tax billing, on infrastructure you own.
+Open-source PMS for hotels and short-term rentals.
 ```
 
-## Tagline alternatives (pick per field length)
-
-- `Open-source PMS for hotels and short-term rentals.`
-- `Run your hotel or villa portfolio — booking, front desk, folios, POS — and bring your own AI.`
+(48 characters.)
 
 ---
 
 ## Long description (About — markdown)
 
+Do not paste install instructions. Frappe Cloud installs the app.
+
 ```markdown
-**Kamra is a complete, open-source property management system for hotels and
-short-term rentals, built on Frappe.** Front desk, direct booking, villa
-catalogs, restaurant POS, housekeeping, folios and tax-correct billing — one
-app, no per-room or per-module rent, and your data stays on infrastructure you
-own.
+A complete property management system for hotels and short-term rentals,
+built on Frappe. Front desk, direct booking, villa catalogs, restaurant POS,
+housekeeping, folios and tax-correct billing — one app, no per-room or
+per-module rent.
 
 Most hotel software was built twenty years ago: click-heavy screens, add-on
-fees for night audit and reports, and your guest and rate history locked in a
-vendor's cloud. Kamra is the alternative — every operation is a governed,
-audited action, so your team (and the AI you trust) can actually run the
-property.
+fees for night audit and reports, and guest history locked in a vendor
+cloud. Kamra treats every operation as a governed, audited action, so your
+team (and the AI you trust) can actually run the property.
 
-### What makes Kamra different
+Install it on your Frappe Cloud site from this listing. The `payments` app
+is pulled in automatically.
 
-- **Agent-ready, not agent-locked.** Kamra ships an MCP server with governed,
-  role-scoped tools. Connect Claude or any MCP client — *"book Mr. Rao a deluxe
-  for the weekend with breakfast"* — it quotes, books, and logs every action.
-  Bring your own AI; there is no bundled model markup or lock-in.
-- **Deterministic money.** Prices, taxes and availability come from a pricing
-  engine, never from a language model. Tax slabs, multi-rate invoices and the
-  no-overbooking guard are code, verified by an eval suite in CI.
-- **Full audit trail.** Every action — human or AI — is logged with who, what
-  and why.
-- **Truly free.** AGPL-licensed. No per-room pricing, no per-seat fees, no
-  license audits. Self-host on-prem or on any cloud, or run it here on Frappe
-  Cloud.
-- **Built on Frappe.** RBAC, multi-tenancy, audit trails and the frappe/payments
-  gateway app come for free.
+### What makes it different
+
+- **Agent-ready, not agent-locked.** An MCP server exposes role-scoped
+  tools. Connect Claude or any MCP client — *"book Mr. Rao a deluxe for the
+  weekend with breakfast"* — it quotes, books, and logs every action. Bring
+  your own AI; there is no bundled model markup.
+- **Deterministic money.** Prices, taxes and availability come from a
+  pricing engine, never from a language model. Tax slabs, multi-rate
+  invoices and the no-overbooking guard are code, verified by an eval suite
+  in CI.
+- **Full audit trail.** Every action — human or AI — is logged with who,
+  what and why.
+- **AGPL and free.** No per-room pricing, no per-seat fees, no license
+  audits. The same code runs on Frappe Cloud and anywhere else you host a
+  Frappe bench.
+- **Built on Frappe.** RBAC, multi-tenancy, audit trails and the
+  frappe/payments gateway app come with the stack.
 
 ### What's inside
 
-- **Front desk** — Today dashboard with paid/due chips, a guided check-in flow
-  with AI room suggestions, tape chart with a live house-position row, ETA/ETD
-  and changeover warnings, guest profile hub, blacklist.
-- **Direct booking engine** — a commission-free, SEO-friendly public booking
-  page with check-in / check-out, Check availability, a photo gallery, live
-  per-date rates, policies, FAQ, map and pay-at-hotel — fully brandable,
-  managed from an in-app console. Hotels get a room grid; short-term rentals
-  get a villa catalog and per-listing pages.
-- **Short-term rentals** — property kind Hotel vs Short Term Rental, sellable
-  units (room, whole-place, package) with competition groups, per-villa
-  locations on the public page, cleaning fees and refundable deposits, Instant
-  or Request-to-book.
-- **Bookings** — multi-room in one flow, group & corporate, booked-on-behalf,
-  returning-guest typeahead, add-ons, travel agents with commissions, day-use.
-- **Revenue** — occupancy-based pricing, seasons, rate plans, vouchers, meal
-  plans, rate guardrails, demand-tier hurdle rates, a code-enforced overbooking
-  allowance, and cancellation/no-show/deposit policies enforced in code.
-- **Billing** — folios with per-line tax, corporate charge routing, group master
-  folios, exact %/amount charge splits, automated night audit, tax invoices with
-  B2B fields, cashier reconciliation, payment links via frappe/payments.
-- **Restaurant POS** — area-wise table map with live states, concurrent & split
-  bills, dine-in / room service / takeaway / delivery, 80mm thermal KOT & bill
-  printing, kitchen display, inventory & recipes, guest QR ordering, room
-  posting (alcohol-aware).
+- **Front desk** — Today dashboard with paid/due chips, a guided check-in
+  flow with AI room suggestions, tape chart with a live house-position row,
+  ETA/ETD and changeover warnings, guest profile hub, blacklist.
+- **Direct booking engine** — a commission-free, SEO-friendly public
+  booking page with check-in / check-out, Check availability, a photo
+  gallery, live per-date rates, policies, FAQ, map and pay-at-hotel —
+  brandable from an in-app console. Hotels get a room grid; short-term
+  rentals get a villa catalog and per-listing pages.
+- **Short-term rentals** — property kind Hotel vs Short Term Rental,
+  sellable units (room, whole-place, package) with competition groups,
+  per-villa locations, cleaning fees and refundable deposits, Instant or
+  Request-to-book.
+- **Bookings** — multi-room in one flow, group & corporate,
+  booked-on-behalf, returning-guest typeahead, add-ons, travel agents with
+  commissions, day-use.
+- **Revenue** — occupancy-based pricing, seasons, rate plans, vouchers,
+  meal plans, rate guardrails, demand-tier hurdle rates, a code-enforced
+  overbooking allowance, and cancellation/no-show/deposit policies
+  enforced in code.
+- **Billing** — folios with per-line tax, corporate charge routing, group
+  master folios, exact %/amount charge splits, automated night audit, tax
+  invoices with B2B fields, cashier reconciliation, payment links via
+  frappe/payments.
+- **Restaurant POS** — area-wise table map with live states, concurrent &
+  split bills, dine-in / room service / takeaway / delivery, 80mm thermal
+  KOT & bill printing, kitchen display, inventory & recipes, guest QR
+  ordering, room posting (alcohol-aware).
 - **Operations** — service tickets with SLA, a housekeeping mobile app,
   end-to-end guest laundry, lost & found, shift handover, venues & events.
-- **Guests** — self check-in with ID & address-proof capture, printable GRC with
-  the legal occupant register, editable actual times, a stay ledger with
-  advances/deposits/guarded refunds, retention-aware ID handling.
-- **Messaging** — WhatsApp on your own Meta Cloud API number: automatic booking
-  confirmations, check-in links, desk payment requests and a conversations inbox.
-- **Localization** — country packs resolved per property: India GST (slabs),
-  Indonesia PB1, Thailand VAT, Malaysia SST, UAE VAT (TRN), and a flat-tax
-  generic for everywhere else; currency and number locale follow the pack.
-- **Platform** — multi-property with per-user scoping, six-role RBAC, dark mode,
-  onboarding wizard, CSV migration importers (eZee / Cloudbeds presets), and a
-  51-check eval harness + 13-journey front-desk persona suite in CI.
+- **Guests** — self check-in with ID & address-proof capture, printable
+  GRC with the legal occupant register, editable actual times, a stay
+  ledger with advances/deposits/guarded refunds, retention-aware ID
+  handling.
+- **Messaging** — WhatsApp on your own Meta Cloud API number: automatic
+  booking confirmations, check-in links, desk payment requests and a
+  conversations inbox.
+- **Localization** — country packs resolved per property: India GST
+  (slabs), Indonesia PB1, Thailand VAT, Malaysia SST, UAE VAT (TRN), and a
+  flat-tax generic for everywhere else; currency and number locale follow
+  the pack.
+- **Platform** — multi-property with per-user scoping, six-role RBAC, dark
+  mode, onboarding wizard, CSV migration importers (eZee / Cloudbeds
+  presets), and a 51-check eval harness + 13-journey front-desk persona
+  suite in CI.
 
-### After you install
+### Try it
 
-Open **`/kamra`** for the product UI (the Desk stays at `/app` as an admin
-escape hatch). Sign in as Administrator and open **`/kamra/setup`** to create
-your property and taxes, then add staff. Full manual at
-**kamrapms.com/docs**.
+Live hotel demo: [demo.kamrapms.com](https://demo.kamrapms.com) — a
+sandbox; role logins are printed on the page.
 
-**Try the live demo first:** [demo.kamrapms.com](https://demo.kamrapms.com) —
-a sandbox pre-loaded with a sample hotel; the role logins are printed on the
-page. For a live short-term rental catalog, see
+Live short-term rental catalog:
 [ewa.kamrapms.com/book](https://ewa.kamrapms.com/kamra/book).
+
+After install, the product UI is at `/kamra`. Sign in as Administrator and
+open `/kamra/setup` to create the first property.
 ```
 
 ---
@@ -140,23 +156,113 @@ Lead with the most legible, "what is this product" shots first.
 
 ## Logo / icon
 
-- **App logo:** `branding/png/kamra-mark-512.png` (or `kamra-square-1024.png`)
+- **App logo:** `branding/png/kamra-mark-512.png` (square, no wordmark —
+  Frappe crops logos into a circle)
 - Desk/app-switcher icon is already wired via `app_logo_url` in `hooks.py`.
 
-## Links
+## Required URLs
 
 | Field | Value |
 |---|---|
+| Support URL | https://kamrapms.com/support |
+| Privacy Policy URL | https://kamrapms.com/privacy |
 | Website | https://kamrapms.com |
 | Documentation | https://kamrapms.com/docs/ |
 | Source | https://github.com/Kamra-PMS/kamra-pms |
-| Support email | hello@kamrapms.com |
+| Terms | https://kamrapms.com/terms |
 | Live demo | https://demo.kamrapms.com |
-| Terms | https://kamrapms.com/terms *(create if the form requires one)* |
-| Privacy | https://kamrapms.com/privacy *(create if the form requires one)* |
+| Support email | hello@kamrapms.com |
 
 ## Publisher profile
 
-- **Publisher:** HeyKoala
+- **Publisher display name:** HeyKoala (or Mohammed Azzan — match the
+  Frappe Cloud team)
 - **Contact:** hello@kamrapms.com
 - **Website:** https://kamrapms.com
+
+## Demo video (reviewers ask for this)
+
+Record a 2–4 minute silent or narrated walkthrough and attach it to the
+Frappe Cloud review / support ticket:
+
+1. Open https://demo.kamrapms.com and show the printed role logins.
+2. Sign in as Front Desk → Today → tape chart → new booking → folio.
+3. Open `/book` and run Check availability.
+4. Optional: https://ewa.kamrapms.com/kamra/book for the villa catalog.
+5. Open `/kamra/setup` only if you want to show first-run (skip if it
+   would mutate the shared demo).
+
+Upload to YouTube (unlisted) or Loom and paste the URL into the listing
+and the support ticket.
+
+---
+
+## Dashboard checklist (unhalt the listing)
+
+The public page already exists at
+https://frappecloud.com/marketplace/apps/kamra and shows **Not Available**.
+Kamra is **not** in the 347 published marketplace apps. Status is Draft /
+no approved release.
+
+In https://frappecloud.com/dashboard → **Marketplace** → **Kamra**:
+
+1. **Overview** — paste Title, Short description, Long description above.
+2. **Category** — Hospitality or Other (currently E-Commerce).
+3. **Logo** — `branding/png/kamra-mark-512.png`.
+4. **Screenshots** — the 13 files above, in that order, with captions.
+5. **Links** — Support + Privacy are mandatory; fill the rest too.
+6. **Releases** — create / select the `main` release at **v2.5.0**
+   (`7a50c56` / tag `v2.5.0`) and click **Publish**.
+7. If a previous request is **Rejected**, cancel it and publish a new
+   one from current `main`.
+8. If the app has been in Draft **more than 10 days**, raise a ticket at
+   https://support.frappe.io/ (SLA in the publishing docs).
+
+### Support ticket (paste)
+
+```
+Subject: Marketplace listing for Kamra (kamra) — request to complete review
+
+Hi Frappe Cloud team,
+
+The Kamra marketplace app is at https://frappecloud.com/marketplace/apps/kamra
+and still shows "Not Available" (Draft / no approved public release).
+
+We submitted earlier; Semgrep findings from that review were fixed in
+https://github.com/Kamra-PMS/kamra-pms/pull/16 and are on main. Stable
+release is v2.5.0 (Frappe v16, AGPL-3.0, required_apps = payments).
+
+Please re-scan main and approve the latest release.
+
+Repo: https://github.com/Kamra-PMS/kamra-pms
+Branch / tag: main / v2.5.0
+Demo: https://demo.kamrapms.com
+Docs: https://kamrapms.com/docs/
+Support: https://kamrapms.com/support
+Privacy: https://kamrapms.com/privacy
+Publisher contact: hello@kamrapms.com
+
+Happy to join a short review call or share a demo video.
+
+Thanks,
+Mohammed Azzan
+HeyKoala
+```
+
+### discuss.frappe.io announcement (after it goes live)
+
+```
+Title: Kamra PMS — open-source hotel & short-term rental PMS on Frappe v16
+
+Kamra is an AGPL property management system for hotels and short-term
+rentals, built on Frappe v16. Front desk, direct booking, villa catalogs,
+POS, housekeeping, folios and tax billing — install from the Frappe Cloud
+Marketplace onto your site.
+
+- Marketplace: https://frappecloud.com/marketplace/apps/kamra
+- Release: https://github.com/Kamra-PMS/kamra-pms/releases/tag/v2.5.0
+- Live demo: https://demo.kamrapms.com
+- Villa catalog: https://ewa.kamrapms.com/kamra/book
+- Docs: https://kamrapms.com/docs/
+- Source: https://github.com/Kamra-PMS/kamra-pms
+```


### PR DESCRIPTION
## Summary
- Add the mandatory Semgrep `linters.yml` workflow (ERROR-severity; local scan is clean).
- Rewrite `docs/marketplace-listing.md` to Frappe guidelines: 48-char short description, no install steps, Frappe Cloud first, Support + Privacy URLs, dashboard + support-ticket paste.
- Point the Frappe Cloud docs page at the live demo instead of Kamra Cloud.

## Why
The marketplace page https://frappecloud.com/marketplace/apps/kamra exists but shows **Not Available**. Kamra is not in the 347 published apps. Reviewers previously sent Semgrep findings (fixed in #16); this adds the CI they require and listing copy that will not get the next review bounced.

## Test plan
- [ ] CI: Linters / Semgrep Rules is green on this PR
- [ ] After merge: paste listing fields into frappecloud.com → Marketplace → Kamra
- [ ] Publish the `main` / v2.5.0 release
- [ ] If still Draft after that, file the support ticket in `docs/marketplace-listing.md`


Made with [Cursor](https://cursor.com)