### PR TITLE
fix: clear Frappe Cloud audit frappe-manual-commit

### DIFF
--- a/docs/marketplace-listing.md
+++ b/docs/marketplace-listing.md
@@ -40,6 +40,8 @@ Open-source PMS for hotels and short-term rentals.
 ## Long description (About — markdown)
 
 Do not paste install instructions. Frappe Cloud installs the app.
+Do not put URLs in the long description — Website / Docs / Support
+fields already hold those; extra links fail the metadata audit.
 
 ```markdown
 A complete property management system for hotels and short-term rentals,
@@ -120,16 +122,12 @@ is pulled in automatically.
   presets), and a 51-check eval harness + 13-journey front-desk persona
   suite in CI.
 
-### Try it
+### After install
 
-Live hotel demo: [demo.kamrapms.com](https://demo.kamrapms.com) — a
-sandbox; role logins are printed on the page.
-
-Live short-term rental catalog:
-[ewa.kamrapms.com/book](https://ewa.kamrapms.com/kamra/book).
-
-After install, the product UI is at `/kamra`. Sign in as Administrator and
-open `/kamra/setup` to create the first property.
+The product UI is at `/kamra`. Sign in as Administrator and open
+`/kamra/setup` to create the first property. Put the live demo and catalog
+on the Website / Documentation fields — Frappe Cloud fails the listing
+audit if the long description contains any other links.
 ```
 
 ---

--- a/kamra/patches/v31/backfill_listing_slugs.py
+++ b/kamra/patches/v31/backfill_listing_slugs.py
@@ -22,4 +22,4 @@ def execute():
 		if updates:
 			frappe.db.set_value("Room Type", name, updates, update_modified=False)
 
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- migration patch runs outside the request cycle; explicit commit persists the backfill

--- a/kamra/reservation_state.py
+++ b/kamra/reservation_state.py
@@ -179,6 +179,5 @@ def expire_holds() -> dict:
 		finally:
 			frappe.flags.kamra_status_transition = False
 			frappe.flags.kamra_cancelling = False
-	if expired:
-		frappe.db.commit()
+	# Scheduler commits at end of the job; do not frappe.db.commit() here.
 	return {"expired": expired}

--- a/kamra/scripts/test_booking_flow.py
+++ b/kamra/scripts/test_booking_flow.py
@@ -199,7 +199,7 @@ def run_tests():
 	finally:
 		# Guarantee Cleanup
 		cleanup_test_data(prop_name)
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit -- bench script runs outside the request cycle; persist cleanup before the process exits
 		print("--- Generic Test Cleanup Complete & All Tests Passed! ---")
 
 def cleanup_test_data(property_name):


### PR DESCRIPTION
## Summary
- Removes the blocking `frappe.db.commit()` in `expire_holds` (AUD-kamra-00002, `kamra/reservation_state.py:183`). Scheduler jobs already commit.
- Adds `# nosemgrep: frappe-manual-commit` on the two remaining unannotated commits (patch + bench script) so the next Submission Gate does not fail the same way.
- Listing copy no longer includes extra URLs (FC metadata warning).

## Test plan
- [ ] Semgrep Rules CI green
- [ ] After merge: new App Release from this SHA, Publish, Submission Gate has 0 Major fails


Made with [Cursor](https://cursor.com)