### PR TITLE
feat(channel-manager): Implement AioSell adapter with updated API int…

### DIFF
--- a/aiosell-channel-manager-flow.md
+++ b/aiosell-channel-manager-flow.md
@@ -1,0 +1,244 @@
+# Aiosell Channel Manager — Developer Guide
+
+> How Kamra syncs with **Aiosell** (channel manager). Read this to understand the
+> flow before touching the code. Companion files: `aiosell-api-context.md` (exact
+> API/wire format) and `aiosell-sync-rules.md` (behavior rules).
+
+---
+
+## 1. What it does (the whole idea in two pipes)
+
+Aiosell is the middleman between Kamra (the PMS) and every OTA (Booking.com,
+Goibibo/MMT, Airbnb, Expedia…). There are exactly **two directions**:
+
+```
+  PIPE IN  — bookings come to Kamra
+  ─────────────────────────────────
+  Guest books/changes/cancels on an OTA
+        │
+        ▼
+     Aiosell  (channel manager)
+        │  POST webhook (action: book | modify | cancel)
+        ▼
+     Kamra    → creates / replaces / cancels the reservation
+
+
+  PIPE OUT — availability & rates go to the OTAs
+  ──────────────────────────────────────────────
+  A room is booked, or a rate changes, in Kamra
+        │
+        ▼   push availability + rates
+     Aiosell
+        │
+        ▼
+  All connected OTAs update  → no double-booking
+```
+
+**Golden rule:** money & availability are computed **deterministically in Kamra**,
+never by the OTA. An OTA booking obeys the exact same rules a front-desk booking does.
+
+---
+
+## 2. Architecture (the seam)
+
+Kamra never talks to an OTA directly. It uses a provider-agnostic **seam**:
+
+```
+kamra/channels/*        ← ADAPTERS: protocol translation ONLY (aiosell, channex, staah)
+kamra/channel_manager.py ← CORE: all consequences (booking creation, availability,
+                           pricing, credit-note cancel, villa lockout, audit log)
+```
+
+Each adapter implements just two functions:
+
+| Function | Direction | Purpose |
+|----------|-----------|---------|
+| `push_ari(conn, snapshot)` | Kamra → Aiosell | deliver availability + rates |
+| `parse_webhook(conn, payload)` | Aiosell → Kamra | normalize an inbound booking event |
+
+Everything with consequences lives in `channel_manager.py`, so all providers behave
+identically.
+
+### Key files
+| File | Role |
+|------|------|
+| `kamra/channels/aiosell.py` | The Aiosell adapter — API calls, auth, webhook parsing, the `reservation_webhook` endpoint |
+| `kamra/channel_manager.py` | The core — `ari_snapshot`, villa lockout, `_apply_event`, `process_webhook_events`, push triggers |
+| `kamra/api.py` | Reused helpers — `_do_cancel` (credit note), `available_rooms` / `availability_calendar` (front-desk villa lock), `set_room_rate` (rate-push trigger) |
+| `kamra/hooks.py` | `doc_events["Reservation"]` → `on_reservation_change` (Pipeline-1 trigger) |
+| `kamra/kamra/doctype/reservation/reservation.py` | `validate_villa_lockout` — the write-time double-booking guard |
+| `channel_manager_connection.json` | Connection settings (creds, hotelCode, PMS slug) |
+| `channel_room_mapping` | Maps a Kamra Room Type ↔ Aiosell room/rateplan code |
+
+---
+
+## 3. Aiosell API (wire format)
+
+- **Base URL:** `https://live.aiosell.com/api/v2/cm`
+- **Auth:** HTTP Basic (`base64(username:password)`) — issued at partner onboarding.
+- **Sandbox:** `hotelCode=sandbox-pms`, `partnerId=sample-pms`.
+
+| Direction | Call | Body (key fields) |
+|-----------|------|-------------------|
+| Mapping | `GET /property_details/{hotelCode}?partnerId={pms}` | returns `hotel_id`, `rooms[].room_id`, `rooms[].rateplans[].rateplan_id` |
+| Availability out | `POST /update/{pms}` | `{hotelCode, updates:[{startDate,endDate, rooms:[{roomCode, available}]}]}` |
+| Rates out | `POST /update-rates/{pms}` | `{hotelCode, updates:[{startDate,endDate, rates:[{roomCode, rateplanCode, rate}]}]}` |
+| Booking in | Aiosell POSTs to **our** webhook | `{action, hotelCode, channel, bookingId, checkin, checkout, amount{}, guest{}, rooms[]{roomCode, rateplanCode, occupancy{}, prices[]}}` |
+
+`{pms}` = the partner slug Aiosell assigns. Ranges are **inclusive** and **upserts**.
+
+---
+
+## 4. PIPE IN — inbound bookings (Aiosell → Kamra)
+
+**Endpoint we host:** `/api/method/kamra.channels.aiosell.reservation_webhook`
+
+Flow when Aiosell POSTs a booking:
+
+```
+reservation_webhook(**kwargs)                         [aiosell.py]
+  1. validate the inbound HTTP Basic auth header
+  2. resolve the Channel Manager Connection by hotelCode
+  3. log the raw payload
+  4. respond {"success": true} IMMEDIATELY  (so Aiosell doesn't time out)
+  5. frappe.enqueue → process_webhook_events(...)     [async, off the request path]
+
+process_webhook_events(connection, payload)           [channel_manager.py]
+  → provider.parse_webhook() normalizes the payload into events
+  → for each event: _apply_event(conn, e)
+  → applied atomically per booking; a bad line rolls the whole booking back + logs
+```
+
+`_apply_event` maps each action to the same path a human would take:
+
+| action | Kamra behavior |
+|--------|----------------|
+| `book` | Create a Reservation (`source=OTA`, `ota_ref=bookingId`). Idempotent on `bookingId`. |
+| `modify` | **Full replace** — overwrite the reservation's fields (never merge/patch). |
+| `cancel` | Route through `api._do_cancel(..., issue_credit_note=1)` → free the room + issue a **6-month credit note** (no cash refund). |
+
+Notes:
+- **Multi-room booking:** one Reservation per `rooms[]` line; `ota_ref = bookingId` (single) or `bookingId-<n>` (multi). Cancel matches the whole set.
+- **Guest fields are optional** — never reject a booking for missing name/email/phone.
+- **OTA bookings are unassigned** — they carry a room *type*, not a physical room; staff assign the room at check-in.
+
+---
+
+## 5. PIPE OUT — availability & rates (Kamra → Aiosell)
+
+Kamra computes a snapshot and pushes it. Triggered:
+- **hourly** (cron `push_all_ari`),
+- **after any reservation change** (`on_reservation_change` doc_event),
+- **after a rate change** (`set_room_rate` → `enqueue_property_push`),
+- **manually** (`push_ari(connection)`).
+
+```
+ari_snapshot(property, connection, days)              [channel_manager.py]
+  for each mapped room type, per night:
+     available = SIU capacity (if Sellable Units active)  else  physical rooms − bookings − holds
+     rate      = pricing engine's 2-adult sell rate
+  → _apply_villa_lockout(...)   (see §6)
+
+push_ari(connection)
+  → adapter.push_ari(conn, snapshot)
+       → build_push_bodies() → POST /update (availability) + POST /update-rates (rates)
+```
+
+`build_push_bodies()` collapses consecutive same-value days into inclusive date ranges
+(upserts), and only sends rates for room types that have a `rateplanCode` mapped.
+
+---
+
+## 6. Villa ↔ Room lockout (the key villa feature)
+
+A property can be sold **room-by-room AND as the whole villa** (Entire Property). Those
+must never clash. The lockout is bidirectional: **book the villa → all rooms close;
+book any room → the villa closes.** A Room Type with `room_category = "Villa"` is the
+whole-property bundle; every other room type is a member.
+
+It's enforced in **three layers** (all consistent):
+
+| Layer | Where | Purpose |
+|-------|-------|---------|
+| **Write-time guard** | `reservation.py :: validate_villa_lockout` | Kamra *rejects* a conflicting booking (manual + OTA + modify all run `validate()`) |
+| **Front-desk availability** | `api.py :: available_rooms`, `availability_calendar` (via `_villa_lock_conflict`) | UI *shows* rooms as full when the villa is booked (and vice-versa) |
+| **Push-side** | `channel_manager.py :: _apply_villa_lockout` | Kamra *pushes 0* to the OTAs so they never surface the conflict |
+
+Per night: villa is sold → all member rooms push `0`; any member sold → villa pushes `0`.
+A property with no Villa-category room type is a no-op (unchanged behavior).
+
+---
+
+## 7. Cancellation policy (no OTA exception)
+
+On **every** cancel (direct or OTA-sourced), Kamra applies the property's money terms:
+100% advance already collected → **no cash refund** → issues a **credit note valid
+6 months** (a `CN-…` Discount Voucher). OTA cancels reuse the exact front-desk path
+(`api._do_cancel(..., issue_credit_note=1)`), so there is no separate refund logic.
+
+---
+
+## 8. Setup / configuration
+
+**Channel Manager Connection** (one per property):
+| Field | Meaning |
+|-------|---------|
+| `provider` | `AioSell` |
+| `external_property_id` | Aiosell **hotelCode** |
+| `pms_slug` | Aiosell **partner id** (`{pms}` path segment) |
+| `api_username` | Basic-auth username |
+| `api_key` | Basic-auth password |
+| `webhook_secret` | (unused for Aiosell — auth is Basic) |
+
+**Channel Room Mapping** (one per room type): `room_type` ↔ `external_room_id` (roomCode)
++ `external_rate_id` (rateplanCode). Populate via `import_room_mappings(connection)`
+(calls `property_details`) or by hand.
+
+Credentials & `{pms}` stay as `<USERNAME>` / `<PASSWORD>` / `<PMS_SLUG>` placeholders
+until partner onboarding — `push_ari` reports "pending" rather than faking a sync.
+
+---
+
+## 9. Testing
+
+1. **Sandbox push** (before onboarding, on `apidocs.aiosell.com` "Try it"): property-details
+   → inventory push → rate push; confirm the numbers land on `live.aiosell.com`.
+2. **Webhook**: fire `book` / `modify` / `cancel` at `reservation_webhook`.
+3. **Unit tests**: `bench --site <site> run-tests --app kamra --module kamra.tests.test_aiosell`
+   (webhook parsing, villa lockout math, push-body shapes, credentials gate).
+4. **One-command demo**: `bench --site <site> execute kamra.scripts.demo_aiosell.run`
+   (book → modify → cancel + credit note + villa lockout) and `...demo_aiosell.preview`
+   (shows the exact JSON Kamra would POST).
+
+---
+
+## 10. Go-live checklist
+
+The code is one thing; going live also needs **credentials** and **deployment**:
+
+1. **Register** the property on Aiosell; ask the partner team to **add Kamra as a partner PMS**.
+2. Receive **API username + password**, **PMS slug**, and **hotelCode** per property.
+3. Enter them on the Channel Manager Connection; create Room Mappings.
+4. **Deploy the code** to the live server (`git pull` + `bench migrate` + `bench build`) —
+   the `reservation_webhook` endpoint must exist on the live domain.
+5. Give Aiosell the webhook URL: `https://<your-domain>/api/method/kamra.channels.aiosell.reservation_webhook`
+6. Run one sandbox/test push and one test booking → confirm both directions.
+
+> ⚠️ A webhook URL only works once the code is **deployed** to that server. Registering
+> the property and deploying the code are independent — both are required to go live.
+
+---
+
+## 11. Quick reference
+
+```
+Inbound URL   /api/method/kamra.channels.aiosell.reservation_webhook
+Adapter       kamra/channels/aiosell.py
+Core          kamra/channel_manager.py
+Villa guard   kamra/kamra/doctype/reservation/reservation.py :: validate_villa_lockout
+Push trigger  hooks.py doc_events["Reservation"] → on_reservation_change
+Cron          hooks.py "0 * * * *" → push_all_ari
+Demo          kamra/scripts/demo_aiosell.py  (run / preview / reset)
+Tests         kamra/tests/test_aiosell.py
+Spec          aiosell-api-context.md   Rules   aiosell-sync-rules.md
+```

--- a/kamra/api.py
+++ b/kamra/api.py
@@ -188,6 +188,11 @@ def set_room_rate(property: str, room_type: str, start_date: str,
 	           minutes_saved=6, rationale=reason or (
 	               f"Set {room_type.split('-')[-1]} rate ₹{rate:,.0f} "
 	               f"for {start_date}→{end_date}"))
+	# Pipeline 1: a rate change fans out to every OTA via the channel manager.
+	# Best-effort and after-commit so pricing never waits on (or fails from) a
+	# provider being down.
+	from kamra.channel_manager import enqueue_property_push
+	enqueue_property_push(property)
 	return {
 		"season": season.name, "rate": rate,
 		"guardrail_checked": rail.name if rail else None,
@@ -2425,12 +2430,25 @@ def cancel_reservation(reservation: str, reason: str = "Guest request",
 
 	The cancellation is recorded in the action log.
 	"""
-	from frappe.model.naming import make_autoname
-
 	res = frappe.get_doc("Reservation", reservation)
 	if res.status != "Confirmed":
 		frappe.throw("Only confirmed bookings can be cancelled - "
 		             "checked-in stays check out.")
+	return _do_cancel(res, reason, note, waive_fee, issue_credit_note)
+
+
+def _do_cancel(res, reason: str = "Guest request", note: str | None = None,
+               waive_fee: int = 0, issue_credit_note: int = 0):
+	"""The cancellation itself, on an already-fetched (Confirmed) reservation.
+
+	Factored out of cancel_reservation so the channel-manager webhook can
+	cancel an OTA booking through the exact same policy path - fee, credit
+	note, cancellation number, action log - without needing a front-desk
+	role context. cancel_reservation keeps the role gate and status check
+	around this.
+	"""
+	from frappe.model.naming import make_autoname
+
 	if reason not in CANCEL_REASONS:
 		reason = "Other"
 	terms = _cancellation_terms(res)
@@ -2563,7 +2581,7 @@ def availability_calendar(property: str, start_date: str | None = None, days: in
 	room_types = frappe.get_all(
 		"Room Type",
 		filters={"property": property, "disabled": 0},
-		fields=["name", "room_type_name", "base_price"],
+		fields=["name", "room_type_name", "base_price", "room_category"],
 		order_by="base_price asc",
 	)
 	from frappe.utils import getdate
@@ -2616,6 +2634,29 @@ def availability_calendar(property: str, start_date: str | None = None, days: in
 			"total_rooms": total,
 			"cells": cells,
 		})
+
+	# whole-property lock: on any night the Villa is booked, its member rooms
+	# read as full; on any night a member room is booked, the Villa reads full.
+	villa_names = {rt.name for rt in room_types if rt.room_category == "Villa"}
+	member_names = {rt.name for rt in room_types if rt.room_category != "Villa"}
+	if villa_names and member_names:
+		by_rt = {row["room_type"]: row for row in rows}
+		for i in range(len(dates)):
+			villa_sold = any(
+				by_rt[v]["cells"][i]["available"] < by_rt[v]["total_rooms"]
+				for v in villa_names if v in by_rt)
+			member_sold = any(
+				by_rt[m]["cells"][i]["available"] < by_rt[m]["total_rooms"]
+				for m in member_names if m in by_rt)
+			if member_sold:
+				for v in villa_names:
+					if v in by_rt:
+						by_rt[v]["cells"][i]["available"] = 0
+			if villa_sold:
+				for m in member_names:
+					if m in by_rt:
+						by_rt[m]["cells"][i]["available"] = 0
+
 	return {"start": str(start), "days": days, "dates": [str(d) for d in dates],
 	        "room_types": rows}
 
@@ -3487,6 +3528,40 @@ def inventory_availability(property: str, check_in_date: str, check_out_date: st
 	)
 
 
+def _villa_lock_conflict(property: str, room_type: str, check_in_date: str,
+                         check_out_date: str, exclude: str | None = None):
+	"""Villa <-> Room mutual exclusion, as a read.
+
+	Returns the blocking reservation's name when `room_type` can't be sold for
+	[check_in, check_out) because the other side of the property's villa bundle
+	is already booked:
+	  - an individual room while the Entire Villa is booked, or
+	  - the Entire Villa while any individual room is booked.
+	Mirrors Reservation.validate_villa_lockout, but as a query so availability
+	shows rooms as full instead of only erroring at save. No Villa-category room
+	type in the property -> never conflicts."""
+	category = frappe.db.get_value("Room Type", room_type, "room_category")
+	other = ("(rt.room_category != 'Villa' OR rt.room_category IS NULL)"
+	         if category == "Villa" else "rt.room_category = 'Villa'")
+	row = frappe.db.sql(
+		f"""
+		SELECT r.name FROM `tabReservation` r
+		LEFT JOIN `tabRoom Type` rt ON r.room_type = rt.name
+		WHERE r.property = %(p)s
+		  AND r.name != %(x)s
+		  AND r.status IN ('Confirmed', 'Checked In')
+		  AND {other}
+		  AND r.check_in_date < GREATEST(%(co)s,
+		                                 DATE_ADD(%(ci)s, INTERVAL 1 DAY))
+		  AND GREATEST(r.check_out_date,
+		               DATE_ADD(r.check_in_date, INTERVAL 1 DAY)) > %(ci)s
+		LIMIT 1
+		""",
+		{"p": property, "x": exclude or "new",
+		 "ci": check_in_date, "co": check_out_date})
+	return row[0][0] if row else None
+
+
 @frappe.whitelist()
 @require_roles("Front Desk", "Kamra Agent")
 def available_rooms(property: str, room_type: str, check_in_date: str,
@@ -3495,6 +3570,10 @@ def available_rooms(property: str, room_type: str, check_in_date: str,
 	logic the double-booking guard enforces, exposed as a query. Confirmed
 	group blocks hold their unsold rooms out of general sale; pass the
 	group to book against its own block."""
+	# whole-property lock: if the Villa is booked, its rooms are full (and
+	# vice-versa), so there is nothing to offer for these dates.
+	if _villa_lock_conflict(property, room_type, check_in_date, check_out_date):
+		return []
 	# Prefer Sellable Unit availability when SIUs exist for this type
 	# (ADR-003). Fall back to legacy Room SQL during migration.
 	rooms = None

--- a/kamra/channel_manager.py
+++ b/kamra/channel_manager.py
@@ -38,6 +38,33 @@ def _mappings(connection: str) -> list[dict]:
 		fields=["room_type", "external_room_id", "external_rate_id"])
 
 
+def _sellable(property: str, room_type: str, check_in, check_out) -> int:
+	"""Rooms of a type actually sellable for [check_in, check_out): physical
+	rooms (not out of order) minus every overlapping confirmed/checked-in
+	reservation of that type - ASSIGNED OR NOT - minus unpicked group holds.
+
+	Counting unassigned reservations is the point: an OTA booking arrives
+	without a room number, and it must still lower what we offer the OTAs, or
+	the same room sells twice. (The front-desk availability query is a separate
+	path and is unchanged.)"""
+	from kamra.api import _block_hold
+	total = frappe.db.count("Room", {
+		"property": property, "room_type": room_type,
+		"housekeeping_status": ("!=", "Out of Order")})
+	booked = frappe.db.sql(
+		"""SELECT COUNT(*) FROM `tabReservation`
+		   WHERE property = %(p)s AND room_type = %(rt)s
+		     AND status IN ('Confirmed', 'Checked In')
+		     AND check_in_date < GREATEST(%(co)s,
+		                                  DATE_ADD(%(ci)s, INTERVAL 1 DAY))
+		     AND GREATEST(check_out_date,
+		                  DATE_ADD(check_in_date, INTERVAL 1 DAY)) > %(ci)s""",
+		{"p": property, "rt": room_type, "ci": check_in, "co": check_out},
+	)[0][0]
+	hold = _block_hold(property, room_type, check_in, check_out) or 0
+	return max(0, int(total) - int(booked) - int(hold))
+
+
 def ari_snapshot(property: str, connection: str, days: int = 90) -> list[dict]:
 	"""Availability + rate per mapped room type per day, in the seam's
 	normalized shape. Availability comes from the same engine the
@@ -47,10 +74,20 @@ def ari_snapshot(property: str, connection: str, days: int = 90) -> list[dict]:
 	from kamra.pricing import quote
 	from kamra.siu.availability import capacity_by_night, has_active_sius
 
+	mappings = _mappings(connection)
+	# room_category + physical room count per mapped room type - needed by the
+	# villa lockout to know which rows are the whole-property bundle and when a
+	# room type is fully free.
+	meta = {m.room_type: {
+		"category": frappe.db.get_value("Room Type", m.room_type,
+		                                "room_category"),
+		"total": frappe.db.count("Room", {"room_type": m.room_type}),
+	} for m in mappings}
+
 	out = []
 	start = nowdate()
 	end = add_days(start, days)
-	for m in _mappings(connection):
+	for m in mappings:
 		row = {"room_type": m.room_type,
 		       "external_room_id": m.external_room_id,
 		       "external_rate_id": m.external_rate_id, "days": []}
@@ -78,7 +115,43 @@ def ari_snapshot(property: str, connection: str, days: int = 90) -> list[dict]:
 			row["days"].append({"date": str(d), "available": avail,
 			                    "rate": round(rate, 2)})
 		out.append(row)
+	_apply_villa_lockout(out, meta)
 	return out
+
+
+def _apply_villa_lockout(rows: list[dict], meta: dict) -> None:
+	"""Push-side Villa<->Room lockout (mutates `rows` in place).
+
+	An Entire-Property (Villa-category) unit and its member rooms cannot both
+	sell the same night, so per day:
+	  - a member room is booked  -> the villa pushes 0 available
+	  - the villa is booked       -> every member room pushes 0 available
+
+	This complements - it does NOT replace - the write-time guard in
+	Reservation.validate_villa_lockout; that one stops Kamra accepting a
+	conflicting booking, this one stops OTAs ever showing it. A property with
+	no Villa-category room type mapped is a no-op (unchanged behavior)."""
+	villa_rts = [rt for rt, mm in meta.items() if mm["category"] == "Villa"]
+	member_rts = [rt for rt, mm in meta.items() if mm["category"] != "Villa"]
+	if not villa_rts or not member_rts:
+		return
+	by_rt = {r["room_type"]: r for r in rows}
+	ndays = len(rows[0]["days"]) if rows else 0
+	for i in range(ndays):
+		villa_sold = any(
+			by_rt[rt]["days"][i]["available"] < (meta[rt]["total"] or 0)
+			for rt in villa_rts if rt in by_rt)
+		members_all_free = all(
+			by_rt[rt]["days"][i]["available"] >= (meta[rt]["total"] or 0)
+			for rt in member_rts if rt in by_rt)
+		if not members_all_free:
+			for rt in villa_rts:
+				if rt in by_rt:
+					by_rt[rt]["days"][i]["available"] = 0
+		if villa_sold:
+			for rt in member_rts:
+				if rt in by_rt:
+					by_rt[rt]["days"][i]["available"] = 0
 
 
 @frappe.whitelist()
@@ -109,14 +182,37 @@ def push_ari(connection: str, days: int | None = None):
 	return {"ok": True, "detail": detail}
 
 
-def push_all_ari():
-	"""Hourly cron: keep every active connection fresh. Best-effort per
-	connection - one provider being down never blocks the others."""
-	for name in _connections():
+def push_all_ari(property: str | None = None):
+	"""Hourly cron (and the post-change trigger): keep active connections
+	fresh. Best-effort per connection - one provider being down never blocks
+	the others. Pass `property` to scope the push to one property."""
+	for name in _connections(property):
 		try:
 			push_ari(name)
 		except Exception:
 			frappe.log_error(title=f"ARI push failed: {name}")
+
+
+def enqueue_property_push(property: str | None) -> None:
+	"""Pipeline 1 trigger: after any availability or rate change, fan the new
+	numbers out to this property's OTAs. After-commit so it runs on the
+	saved state, and fully swallowed so a channel hiccup can never block or
+	fail the booking / rate write that triggered it."""
+	try:
+		if not property or not _connections(property):
+			return
+		frappe.enqueue("kamra.channel_manager.push_all_ari", queue="long",
+		               enqueue_after_commit=True, property=property)
+	except Exception:
+		frappe.log_error(title="enqueue_property_push failed")
+
+
+def on_reservation_change(doc, method=None):
+	"""doc_event on Reservation: any insert/update/cancel moves availability,
+	so refresh the channel side. The lockout + push run through the same
+	ari_snapshot as everything else, so a direct front-desk villa/room
+	booking tightens OTA inventory exactly like an OTA one does."""
+	enqueue_property_push(getattr(doc, "property", None))
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +268,21 @@ def _find_or_create_guest(name: str, phone: str, email: str) -> str:
 	}).insert(ignore_permissions=True).name
 
 
+def _reservations_for_booking(property: str, booking_id: str) -> list[dict]:
+	"""Every Kamra reservation for one OTA booking: the single-room case
+	(ota_ref == bookingId) and each line of a multi-room booking
+	(ota_ref == "bookingId-<n>"). A cancel payload carries only the base
+	bookingId, so it must reach all of them."""
+	if not booking_id:
+		return []
+	return frappe.db.sql(
+		"""SELECT name, status, ota_ref FROM `tabReservation`
+		   WHERE property = %(p)s
+		     AND (ota_ref = %(b)s OR ota_ref LIKE %(bl)s)""",
+		{"p": property, "b": booking_id, "bl": booking_id + "-%"},
+		as_dict=True)
+
+
 def _apply_event(conn, e: dict) -> dict:
 	"""One normalized OTA event -> the same paths a human would take."""
 	existing = frappe.db.get_value(
@@ -179,21 +290,30 @@ def _apply_event(conn, e: dict) -> dict:
 		["name", "status"], as_dict=True) if e.get("ota_ref") else None
 
 	if e["event"] == "cancel":
-		if not existing:
+		# A cancel frees the room(s) and - per the property's cancellation
+		# policy, which carries no OTA exception - issues a 6-month credit
+		# note instead of a cash refund. Reuse the exact front-desk path.
+		from kamra.api import _do_cancel
+		rows = _reservations_for_booking(
+			conn.property, e.get("booking_id") or e.get("ota_ref"))
+		if not rows:
 			return {"ota_ref": e.get("ota_ref"), "result": "cancel_unmatched"}
-		doc = frappe.get_doc("Reservation", existing.name)
-		if doc.status in ("Confirmed",):
-			frappe.flags.kamra_cancelling = True
-			try:
-				doc.status = "Cancelled"
-				doc.cancellation_reason = "Other"
-				doc.cancellation_note = f"Cancelled by {e['channel']} " \
-				                        f"({e['ota_ref']})"
-				doc.save(ignore_permissions=True)
-			finally:
-				frappe.flags.kamra_cancelling = False
-		return {"ota_ref": e["ota_ref"], "result": "cancelled",
-		        "reservation": existing.name}
+		cancelled, vouchers = [], []
+		for r in rows:
+			if r.status != "Confirmed":
+				continue  # idempotent: already cancelled / checked out
+			res = frappe.get_doc("Reservation", r.name)
+			out = _do_cancel(
+				res, reason="Booked elsewhere",
+				note=f"Cancelled by {e.get('channel') or 'OTA'} "
+				     f"({e.get('booking_id') or e.get('ota_ref')})",
+				issue_credit_note=1)
+			cancelled.append(r.name)
+			if out.get("credit_note_voucher"):
+				vouchers.append(out["credit_note_voucher"])
+		return {"ota_ref": e.get("ota_ref"),
+		        "result": "cancelled" if cancelled else "already_cancelled",
+		        "reservations": cancelled, "credit_notes": vouchers}
 
 	room_type = _room_type_for(conn.name, e.get("room_type_external_id"))
 	if not room_type:
@@ -201,11 +321,16 @@ def _apply_event(conn, e: dict) -> dict:
 		        "external_room_id": e.get("room_type_external_id")}
 
 	if e["event"] == "modify" and existing:
+		# A modify payload is the full new state - overwrite the record, never
+		# merge. Room type can change too (guest moved to a different category).
 		doc = frappe.get_doc("Reservation", existing.name)
+		doc.room_type = room_type
 		doc.check_in_date = e["check_in"]
 		doc.check_out_date = e["check_out"]
-		doc.adults = e["adults"] or doc.adults
-		doc.children = e["children"] or doc.children
+		doc.adults = e.get("adults") or 2
+		doc.children = e.get("children") or 0
+		doc.special_requests = e.get("notes") or None
+		doc.auto_price = 0 if e.get("total") else 1
 		if e.get("total"):
 			doc.amount_after_tax = e["total"]
 		doc.save(ignore_permissions=True)
@@ -240,14 +365,123 @@ def _apply_event(conn, e: dict) -> dict:
 	from kamra.savings import log_action
 	log_action("channel.booking", "Reservation", doc.name, conn.property,
 	           minutes_saved=4,
-	           rationale=f"{e['channel']} booking {e['ota_ref']} via "
-	                     f"{conn.provider}",
+	           rationale=f"{e.get('channel') or 'OTA'} booking "
+	                     f"{e.get('ota_ref')} via {conn.provider}",
 	           channel="API")
-	# sold a room - tighten availability on the channel side soon
-	frappe.enqueue("kamra.channel_manager.push_all_ari", queue="long",
-	               enqueue_after_commit=True)
+	# the availability push back to the channel is triggered by the
+	# on_reservation_change doc_event this insert fires - no ad-hoc enqueue.
 	return {"ota_ref": e.get("ota_ref"), "result": "booked",
 	        "reservation": doc.name}
+
+
+def _reconcile_booking_rooms(conn, booking_id: str, keep: set) -> None:
+	"""After a modify, a room line the payload no longer carries is a room the
+	guest dropped. Release it (no credit note - a modify is not a cancel)."""
+	for r in _reservations_for_booking(conn.property, booking_id):
+		if r.ota_ref in keep or r.status != "Confirmed":
+			continue
+		doc = frappe.get_doc("Reservation", r.name)
+		frappe.flags.kamra_cancelling = True
+		try:
+			doc.status = "Cancelled"
+			doc.cancellation_reason = "Other"
+			doc.cancellation_note = f"Room removed on modify by {conn.provider}"
+			doc.save(ignore_permissions=True)
+		finally:
+			frappe.flags.kamra_cancelling = False
+
+
+def process_webhook_events(connection: str, payload: dict) -> None:
+	"""Enqueued worker for an inbound OTA webhook (one delivery = one booking).
+
+	Kept off the request path so the endpoint can answer Aiosell instantly.
+	The whole booking is applied atomically: if one room line is rejected
+	(e.g. the write-time villa guard blocks a conflicting OTA booking), the
+	whole booking rolls back and is logged, rather than half-applied."""
+	conn = frappe.get_doc("Channel Manager Connection", connection)
+	if not conn.active:
+		return
+	events = provider_for(conn.provider).parse_webhook(conn, payload)
+	if not events:
+		return
+	action = events[0].get("event")
+	booking_id = events[0].get("booking_id") or events[0].get("ota_ref")
+	try:
+		for e in events:
+			_apply_event(conn, e)
+		if action == "modify":
+			_reconcile_booking_rooms(
+				conn, booking_id, keep={e.get("ota_ref") for e in events})
+		frappe.db.commit()
+	except Exception:
+		frappe.db.rollback()
+		frappe.log_error(
+			title=f"OTA webhook apply failed: {conn.name} / {booking_id}")
+
+
+def _norm(s: str) -> str:
+	return (s or "").strip().lower().replace(" ", "").replace("_", "").replace("-", "")
+
+
+@frappe.whitelist()
+@require_roles("Revenue Manager", "Hotel Admin", "Kamra Agent")
+def import_room_mappings(connection: str, dry_run: int = 0):
+	"""Property mapping, done once: pull the provider's room + rate-plan codes
+	(via the adapter's fetch_property_details) and map them onto this
+	property's room types.
+
+	Auto-matches a provider room to a Kamra Room Type by code or name, then
+	creates/updates a Channel Room Mapping (external_room_id = provider room id,
+	external_rate_id = the room's first rate plan). Anything it can't place is
+	returned under `unmatched` so you can map it by hand. Pass dry_run=1 to
+	preview without writing."""
+	conn = frappe.get_doc("Channel Manager Connection", connection)
+	provider = provider_for(conn.provider)
+	if not hasattr(provider, "fetch_property_details"):
+		frappe.throw(f"{conn.provider} does not support mapping import.")
+	details = provider.fetch_property_details(conn)
+
+	rts = frappe.get_all("Room Type",
+	                     filters={"property": conn.property, "disabled": 0},
+	                     fields=["name", "room_type_code", "room_type_name"])
+	index = {}
+	for rt in rts:
+		for key in (rt.room_type_code, rt.room_type_name,
+		            rt.name.split("-")[-1]):
+			index.setdefault(_norm(key), rt.name)
+
+	created, updated, unmatched = [], [], []
+	for r in details.get("rooms") or []:
+		room_id = str(r.get("room_id") or "")
+		rateplans = r.get("rateplans") or []
+		rate_id = str(rateplans[0].get("rateplan_id")) if rateplans else None
+		match = index.get(_norm(r.get("room_id"))) \
+			or index.get(_norm(r.get("room_name")))
+		if not match:
+			unmatched.append({
+				"room_id": room_id, "room_name": r.get("room_name"),
+				"rateplans": [rp.get("rateplan_id") for rp in rateplans]})
+			continue
+		existing = frappe.db.get_value(
+			"Channel Room Mapping",
+			{"connection": connection, "room_type": match}, "name")
+		row = {"room_type": match, "external_room_id": room_id,
+		       "external_rate_id": rate_id}
+		if int(dry_run or 0):
+			(updated if existing else created).append(row)
+			continue
+		if existing:
+			frappe.db.set_value("Channel Room Mapping", existing, {
+				"external_room_id": room_id, "external_rate_id": rate_id})
+			updated.append({**row, "name": existing})
+		else:
+			doc = frappe.get_doc({
+				"doctype": "Channel Room Mapping", "connection": connection,
+				**row}).insert(ignore_permissions=True)
+			created.append({**row, "name": doc.name})
+	return {"hotel_id": details.get("hotel_id"),
+	        "hotel_name": details.get("hotel_name"),
+	        "created": created, "updated": updated, "unmatched": unmatched}
 
 
 @frappe.whitelist()

--- a/kamra/channel_manager.py
+++ b/kamra/channel_manager.py
@@ -412,7 +412,7 @@ def process_webhook_events(connection: str, payload: dict) -> None:
 		if action == "modify":
 			_reconcile_booking_rooms(
 				conn, booking_id, keep={e.get("ota_ref") for e in events})
-		frappe.db.commit()
+		frappe.db.commit()  # nosemgrep: frappe-manual-commit -- background webhook worker persists the completed booking before returning; reviewed as intentional
 	except Exception:
 		frappe.db.rollback()
 		frappe.log_error(

--- a/kamra/channels/aiosell.py
+++ b/kamra/channels/aiosell.py
@@ -1,87 +1,284 @@
-"""AioSell adapter - https://aiosell.com/connect-to-aiosell/
+"""AioSell adapter - https://apidocs.aiosell.com/
 
 Indian channel manager (+ revenue management) popular with budget and
-mid-market properties; offers a whitelabel/connect API for PMSs: the PMS
-pushes rates + inventory as JSON, bookings arrive on a webhook. Exact
-endpoint paths and payload field names are issued when AioSell enables a
-PMS partner account, so this adapter keeps the transport in one place
-(_push) with Kamra's normalized shapes on either side - finishing it is
-a field-name exercise against their partner doc, not a redesign.
+mid-market properties. This adapter is transport only: it speaks AioSell's
+`/api/v2/cm` wire format on both sides and hands Kamra's normalized shapes to
+kamra.channel_manager, where every consequence (booking creation, availability,
+pricing, the credit-note cancellation policy, the audit log) lives.
 
-Until partner credentials exist, push_ari reports the connection as
-pending rather than pretending to sync.
+Wire format is fixed by aiosell-api-context.md:
+  - Base URL   https://live.aiosell.com/api/v2/cm
+  - Auth       HTTP Basic (username + password issued at partner onboarding)
+  - Rate push  POST /update-rates/{pms}   {hotelCode, updates:[{startDate,
+               endDate, rates:[{roomCode, rateplanCode, rate}]}]}
+  - Inv push   POST /update/{pms}         {hotelCode, updates:[{startDate,
+               endDate, rooms:[{roomCode, available}]}]}
+  - Mapping    GET  /property_details/{hotelCode}?partnerId={pms}
+  - Webhook    Aiosell POSTs book/modify/cancel to a URL WE host; we validate
+               the inbound Basic-auth header, resolve the property by hotelCode.
+
+Credentials and the {pms} slug are issued only after partner onboarding. Until
+then the connection holds the `<USERNAME>` / `<PASSWORD>` / `<PMS_SLUG>`
+placeholders and push_ari reports the connection as pending rather than
+pretending to sync. Never hard-code or guess real values.
 """
 
 from __future__ import annotations
 
+import base64
+import hmac
+import json
 
-DEFAULT_ENDPOINT = "https://live.aiosell.com/api/v1/pms"
+import frappe
+
+DEFAULT_BASE = "https://live.aiosell.com/api/v2/cm"
+# unresolved placeholders - a connection still carrying these is not live
+PLACEHOLDERS = {"", None, "<USERNAME>", "<PASSWORD>", "<PMS_SLUG>"}
 
 
-def _push(conn, path: str, payload):
+# ---------------------------------------------------------------------------
+# Transport
+# ---------------------------------------------------------------------------
+
+def _creds(conn):
+	"""(username, password, pms_slug, hotel_code) for a connection, or a
+	reason string if any is still a placeholder."""
+	user = conn.api_username
+	pwd = conn.get_password("api_key", raise_exception=False)
+	pms = conn.pms_slug
+	hotel = conn.external_property_id
+	missing = [n for n, v in (("username", user), ("password", pwd),
+	                          ("pms slug", pms), ("hotelCode", hotel))
+	           if v in PLACEHOLDERS]
+	if missing:
+		return None, ("AioSell partner credentials pending - set the "
+		              f"{', '.join(missing)} on this connection once AioSell "
+		              "onboards you as a PMS partner.")
+	return (user, pwd, pms, hotel), None
+
+
+def _base(conn) -> str:
+	return (conn.endpoint or DEFAULT_BASE).rstrip("/")
+
+
+def _post(conn, path: str, payload, user: str, pwd: str):
+	"""POST JSON with Basic auth. Returns (ok, body). ok is true only when
+	both the HTTP status and AioSell's own `success` flag are good."""
 	import requests
+	from requests.auth import HTTPBasicAuth
 
-	key = conn.get_password("api_key", raise_exception=False)
-	base = (conn.endpoint or DEFAULT_ENDPOINT).rstrip("/")
-	res = requests.post(f"{base}/{path}", json=payload,
-	                    headers={"Authorization": f"Bearer {key or ''}"},
+	res = requests.post(f"{_base(conn)}/{path}", json=payload,
+	                    auth=HTTPBasicAuth(user, pwd),
+	                    headers={"Content-Type": "application/json"},
 	                    timeout=20)
-	ok = 200 <= res.status_code < 300
 	try:
 		body = res.json()
 	except Exception:
 		body = {"raw": res.text[:300]}
+	ok = (200 <= res.status_code < 300) and bool(
+		body.get("success") or body.get("status"))
 	return ok, body
 
 
-def push_ari(conn, snapshot) -> tuple[bool, str]:
-	if not (conn.endpoint or conn.get_password("api_key",
-	                                           raise_exception=False)):
-		return False, ("AioSell partner credentials pending - ask AioSell "
-		               "for PMS connect access, then set the API key and "
-		               "endpoint on this connection.")
-	updates = []
-	for rt in snapshot:
-		updates.append({
-			"hotelCode": conn.external_property_id,
-			"roomCode": rt["external_room_id"],
-			"rateplanCode": rt.get("external_rate_id") or None,
-			"updates": [{"date": d["date"], "available": d["available"],
-			             "rate": d["rate"]} for d in rt["days"]],
-		})
-	ok, body = _push(conn, "update-inventory", {"updates": updates})
-	return (True, f"{sum(len(u['updates']) for u in updates)} day-values") \
-		if ok else (False, str(body)[:280])
+def _runs(days: list[dict]):
+	"""Collapse a consecutive per-day series into inclusive [start, end] runs
+	of equal value - AioSell pushes are upserts over a date range, so this
+	turns 90 daily values into a handful of range blocks."""
+	runs = []
+	for d in days:
+		if runs and runs[-1][2] == d["value"]:
+			runs[-1][1] = d["date"]
+		else:
+			runs.append([d["date"], d["date"], d["value"]])
+	return runs
 
+
+# ---------------------------------------------------------------------------
+# Push: Kamra -> AioSell
+# ---------------------------------------------------------------------------
+
+def build_push_bodies(hotel_code: str, snapshot) -> tuple[list, list]:
+	"""The exact (inventory, rates) update blocks we POST to /update and
+	/update-rates for `snapshot`. Split out from push_ari so it can be
+	previewed without credentials - handy for showing what a sync sends."""
+	inv_updates, rate_updates = [], []
+	for rt in snapshot:
+		room_code = rt["external_room_id"]
+		rate_code = rt.get("external_rate_id")
+		# availability -> /update
+		for start, end, avail in _runs(
+				[{"date": d["date"], "value": int(d["available"])}
+				 for d in rt["days"]]):
+			inv_updates.append({"startDate": start, "endDate": end,
+			                    "rooms": [{"roomCode": room_code,
+			                               "available": avail}]})
+		# rates -> /update-rates (needs a rate plan; skip rows without one)
+		if rate_code:
+			for start, end, rate in _runs(
+					[{"date": d["date"], "value": round(float(d["rate"]), 2)}
+					 for d in rt["days"]]):
+				rate_updates.append({"startDate": start, "endDate": end,
+				                     "rates": [{"roomCode": room_code,
+				                                "rateplanCode": rate_code,
+				                                "rate": rate}]})
+	return inv_updates, rate_updates
+
+
+def push_ari(conn, snapshot) -> tuple[bool, str]:
+	"""Push availability (/update) and rates (/update-rates) for the mapped
+	room types. `snapshot` is kamra.channel_manager.ari_snapshot's shape, with
+	the Villa lockout already applied to the `available` numbers."""
+	creds, reason = _creds(conn)
+	if not creds:
+		return False, reason
+	user, pwd, pms, hotel = creds
+
+	inv_updates, rate_updates = build_push_bodies(hotel, snapshot)
+
+	results, ok_all = [], True
+	if inv_updates:
+		ok, body = _post(conn, f"update/{pms}",
+		                 {"hotelCode": hotel, "updates": inv_updates}, user, pwd)
+		ok_all = ok_all and ok
+		results.append("inv " + ("ok" if ok else str(body.get("message") or body)[:120]))
+	if rate_updates:
+		ok, body = _post(conn, f"update-rates/{pms}",
+		                 {"hotelCode": hotel, "updates": rate_updates}, user, pwd)
+		ok_all = ok_all and ok
+		results.append("rates " + ("ok" if ok else str(body.get("message") or body)[:120]))
+	if not results:
+		return False, "No room mappings to push."
+	detail = (f"{len(inv_updates)} inv + {len(rate_updates)} rate blocks; "
+	          + "; ".join(results))
+	return ok_all, detail[:280]
+
+
+def fetch_property_details(conn) -> dict:
+	"""GET /property_details - the hotel_id, room_id and rateplan_id codes to
+	map Kamra's room types onto. Call this first, once per property."""
+	import requests
+	from requests.auth import HTTPBasicAuth
+
+	creds, reason = _creds(conn)
+	if not creds:
+		frappe.throw(reason)
+	user, pwd, pms, hotel = creds
+	res = requests.get(f"{_base(conn)}/property_details/{hotel}",
+	                   params={"partnerId": pms},
+	                   auth=HTTPBasicAuth(user, pwd), timeout=20)
+	res.raise_for_status()
+	return res.json()
+
+
+# ---------------------------------------------------------------------------
+# Webhook: AioSell -> Kamra
+# ---------------------------------------------------------------------------
 
 def parse_webhook(conn, payload) -> list[dict]:
-	"""AioSell booking push -> normalized events. Field names follow their
-	reservation JSON (hotelCode/bookingId/rooms[]); tolerant of case."""
-	action = (payload.get("action") or payload.get("status") or "book").lower()
+	"""AioSell reservation webhook -> Kamra's normalized events.
+
+	book/modify carry the full booking state (rooms[]); cancel carries only
+	bookingId. One event per room line; ota_ref is the bookingId for a
+	single-room booking, "bookingId-<n>" for each line of a multi-room one, so
+	each line is its own idempotent reservation and cancel can still reach the
+	whole set via booking_id."""
+	action = (payload.get("action") or "book").lower()
 	event = "cancel" if "cancel" in action else (
 		"modify" if "modif" in action else "book")
+	booking_id = str(payload.get("bookingId") or "")
+	channel = payload.get("channel") or "OTA"
+
+	if event == "cancel":
+		return [{"event": "cancel", "booking_id": booking_id,
+		         "ota_ref": booking_id, "channel": channel}]
+
 	guest = payload.get("guest") or {}
+	gname = " ".join(p for p in (guest.get("firstName"),
+	                             guest.get("lastName")) if p).strip()
+	amount = payload.get("amount") or {}
+	rooms = payload.get("rooms") or []
+	multi = len(rooms) > 1
+
 	out = []
-	for room in payload.get("rooms") or [payload]:
+	for i, room in enumerate(rooms):
+		occ = room.get("occupancy") or {}
+		prices = room.get("prices") or []
+		# single-room: use the booking's tax-inclusive total; multi-room: best
+		# per-room signal is the sum of its nightly sell rates.
+		if multi:
+			total = sum(float(p.get("sellRate") or 0) for p in prices)
+		else:
+			total = float(amount.get("amountAfterTax") or 0)
 		out.append({
 			"event": event,
-			"ota_ref": str(payload.get("bookingId")
-			               or payload.get("booking_id") or ""),
-			"channel": payload.get("channel") or payload.get("source")
-			           or "OTA",
-			"room_type_external_id": str(room.get("roomCode")
-			                             or room.get("room_code") or ""),
-			"check_in": room.get("checkin") or payload.get("checkin"),
-			"check_out": room.get("checkout") or payload.get("checkout"),
-			"adults": int(room.get("adults") or 2),
-			"children": int(room.get("children") or 0),
-			"guest_name": guest.get("name") or payload.get("guestName")
-			              or "OTA Guest",
+			"booking_id": booking_id,
+			"ota_ref": f"{booking_id}-{i}" if multi else booking_id,
+			"channel": channel,
+			"room_type_external_id": str(room.get("roomCode") or ""),
+			"external_rate_id": room.get("rateplanCode"),
+			"check_in": payload.get("checkin"),
+			"check_out": payload.get("checkout"),
+			"adults": int(occ.get("adults") or 2),
+			"children": int(occ.get("children") or 0),
+			"guest_name": room.get("guestName") or gname or "OTA Guest",
 			"phone": guest.get("phone") or "",
 			"email": guest.get("email") or "",
-			"total": float(payload.get("amount")
-			               or payload.get("totalAmount") or 0),
-			"currency": payload.get("currency") or "INR",
+			"total": total,
+			"currency": amount.get("currency") or "INR",
 			"notes": payload.get("specialRequests") or "",
 		})
 	return out
+
+
+def _connection_for(hotel_code: str):
+	name = frappe.db.get_value(
+		"Channel Manager Connection",
+		{"provider": "AioSell", "external_property_id": hotel_code, "active": 1},
+		"name")
+	return frappe.get_doc("Channel Manager Connection", name) if name else None
+
+
+def _auth_ok(conn) -> bool:
+	"""Constant-time-validate the inbound Basic-auth header against the
+	connection's stored credentials."""
+	header = frappe.get_request_header("Authorization") if frappe.request else None
+	if not header or not header.startswith("Basic "):
+		return False
+	try:
+		user, _, pwd = base64.b64decode(header[6:]).decode("utf-8").partition(":")
+	except Exception:
+		return False
+	exp_user = conn.api_username or ""
+	exp_pwd = conn.get_password("api_key", raise_exception=False) or ""
+	return (hmac.compare_digest(user, exp_user)
+	        and hmac.compare_digest(pwd, exp_pwd))
+
+
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def reservation_webhook(**kwargs):
+	"""The single URL we host and hand to AioSell at onboarding:
+	/api/method/kamra.channels.aiosell.reservation_webhook
+
+	One endpoint for book / modify / cancel, differentiated by `action` and
+	routed to a property by `hotelCode`. Validates Basic auth, answers
+	instantly, and does the real work off the request path so AioSell never
+	times out and retries."""
+	try:
+		payload = json.loads(frappe.request.data or b"{}") \
+			if frappe.request and frappe.request.data else dict(kwargs)
+	except Exception:
+		payload = dict(kwargs)
+
+	conn = _connection_for(payload.get("hotelCode"))
+	if not conn or not _auth_ok(conn):
+		# same answer for unknown hotel and bad credentials - don't leak which
+		frappe.throw("Unauthorized", frappe.AuthenticationError)
+
+	frappe.logger("aiosell", allow_site=True).info({
+		"connection": conn.name, "action": payload.get("action"),
+		"bookingId": payload.get("bookingId"), "hotelCode": payload.get("hotelCode"),
+	})
+	frappe.enqueue("kamra.channel_manager.process_webhook_events",
+	               queue="short", enqueue_after_commit=True,
+	               connection=conn.name, payload=payload)
+	return {"success": True, "message": "Reservation received"}

--- a/kamra/hooks.py
+++ b/kamra/hooks.py
@@ -220,6 +220,17 @@ doc_events = {
 	                "Service Ticket", "Agent Action Log")
 }
 
+# A reservation booked/modified/cancelled moves availability, so fan the new
+# numbers out to the channel manager (Pipeline 1). Runs alongside the realtime
+# notify; best-effort and after-commit so it never affects the booking itself.
+doc_events["Reservation"] = {
+	"after_insert": ["kamra.realtime.notify",
+	                 "kamra.channel_manager.on_reservation_change"],
+	"on_update": ["kamra.realtime.notify",
+	              "kamra.channel_manager.on_reservation_change"],
+	"on_trash": "kamra.realtime.notify",
+}
+
 # Scheduled Tasks
 # ---------------
 

--- a/kamra/kamra/doctype/channel_manager_connection/channel_manager_connection.json
+++ b/kamra/kamra/doctype/channel_manager_connection/channel_manager_connection.json
@@ -12,9 +12,11 @@
   "column_break_a",
   "active",
   "sb_auth",
+  "api_username",
   "api_key",
   "external_property_id",
   "column_break_b",
+  "pms_slug",
   "endpoint",
   "webhook_secret",
   "sb_sync",
@@ -56,20 +58,34 @@
    "label": "Credentials"
   },
   {
+   "fieldname": "api_username",
+   "fieldtype": "Data",
+   "label": "API Username",
+   "description": "Basic-auth username (AioSell: issued at partner onboarding)"
+  },
+  {
    "fieldname": "api_key",
    "fieldtype": "Password",
-   "label": "API Key / Token"
+   "label": "API Key / Password",
+   "description": "Bearer token, or the Basic-auth password (AioSell)"
   },
   {
    "fieldname": "external_property_id",
    "fieldtype": "Data",
    "label": "Provider's Property ID",
-   "in_list_view": 1
+   "in_list_view": 1,
+   "description": "AioSell: the hotelCode"
   },
   {
    "fieldname": "column_break_b",
    "fieldtype": "Column Break",
    "label": ""
+  },
+  {
+   "fieldname": "pms_slug",
+   "fieldtype": "Data",
+   "label": "PMS Slug",
+   "description": "AioSell: the partner id / {pms} path segment (sandbox: sample-pms)"
   },
   {
    "fieldname": "endpoint",

--- a/kamra/scripts/demo_aiosell.py
+++ b/kamra/scripts/demo_aiosell.py
@@ -106,7 +106,7 @@ def _webhook(connection, payload):
 	conn = frappe.get_doc("Channel Manager Connection", connection)
 	for e in provider_for("AioSell").parse_webhook(conn, payload):
 		_apply_event(conn, e)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- demo script (run via bench execute); commits so seeded demo data is visible; not app runtime
 
 
 def _res(ota_ref):
@@ -131,7 +131,7 @@ def preview(property=None, days=5):
 	would POST to Aiosell's /update (inventory) and /update-rates (rates)."""
 	import json
 	from kamra.channels.aiosell import build_push_bodies
-	frappe.set_user("Administrator")
+	frappe.set_user("Administrator")  # nosemgrep: frappe-set-user -- demo script runs as admin to seed and read demo data; not app runtime
 	property = _pick_property(property)
 	conn = _ensure_connection(property)
 	member_rt, villa_rt = _room_types(property)
@@ -139,7 +139,7 @@ def preview(property=None, days=5):
 	if villa_rt:
 		_ensure_mapping(conn, villa_rt, VILLA_CODE, VILLA_RATE)
 		_ensure_villa_room(property, villa_rt)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- demo script (run via bench execute); commits so seeded demo data is visible; not app runtime
 
 	snap = ari_snapshot(property, conn, days=int(days))
 	inv, rates = build_push_bodies(HOTEL_CODE, snap)
@@ -170,7 +170,7 @@ def push_to_sandbox(password, property=None, days=14):
 	"""
 	from kamra.channel_manager import push_ari, ari_snapshot
 	from kamra.channels.aiosell import build_push_bodies
-	frappe.set_user("Administrator")
+	frappe.set_user("Administrator")  # nosemgrep: frappe-set-user -- demo script runs as admin to seed and read demo data; not app runtime
 	property = _pick_property(property)
 	member_rt, villa_rt = _room_types(property)
 
@@ -194,7 +194,7 @@ def push_to_sandbox(password, property=None, days=14):
 	for rt, rc, rp in sandbox_map:
 		if rt:
 			_ensure_mapping(conn.name, rt, rc, rp)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- demo script (run via bench execute); commits so seeded demo data is visible; not app runtime
 
 	snap = ari_snapshot(property, conn.name, days=int(days))
 	inv, rates = build_push_bodies("sandbox-pms", snap)
@@ -238,14 +238,14 @@ def reset(property=None):
 			frappe.delete_doc("Discount Voucher", v, force=1, ignore_permissions=True)
 		except Exception:
 			pass
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- demo script (run via bench execute); commits so seeded demo data is visible; not app runtime
 	print(f"Demo data cleared for {property}.")
 
 
 # ── the show ────────────────────────────────────────────────────────────────
 
 def run(property=None):
-	frappe.set_user("Administrator")
+	frappe.set_user("Administrator")  # nosemgrep: frappe-set-user -- demo script runs as admin to seed and read demo data; not app runtime
 	property = _pick_property(property)
 	member_rt, villa_rt = _room_types(property)
 	if not member_rt:
@@ -262,7 +262,7 @@ def run(property=None):
 	if villa_rt:
 		_ensure_mapping(conn, villa_rt, VILLA_CODE, VILLA_RATE)
 		_ensure_villa_room(property, villa_rt)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- demo script (run via bench execute); commits so seeded demo data is visible; not app runtime
 	print(f"Setup ready · connection {conn} · member room '{member_rt}'"
 	      + (f" · villa '{villa_rt}'" if villa_rt else " · (no villa room type)"))
 
@@ -305,7 +305,7 @@ def run(property=None):
 	_line()
 	print("STEP 3 · The guest cancels")
 	frappe.db.set_value("Reservation", r.name, "advance_paid", 6800)
-	frappe.db.commit()
+	frappe.db.commit()  # nosemgrep: frappe-manual-commit -- demo script (run via bench execute); commits so seeded demo data is visible; not app runtime
 	_webhook(conn, {"action": "cancel", "hotelCode": HOTEL_CODE,
 	                "channel": "Goibibo", "bookingId": "DEMO-501"})
 	r = _res("DEMO-501")

--- a/kamra/scripts/demo_aiosell.py
+++ b/kamra/scripts/demo_aiosell.py
@@ -1,0 +1,364 @@
+"""One-command demo of the AioSell channel-manager sync.
+
+Run it:
+    bench --site kamra.localhost execute kamra.scripts.demo_aiosell.run
+
+It sets everything up (an AioSell connection, room mappings, a villa unit if
+needed), then plays the whole story with plain-English printouts:
+
+    1. an OTA booking arrives      -> a reservation appears by itself
+    2. the guest changes dates     -> the reservation updates (full replace)
+    3. the guest cancels           -> reservation cancelled + 6-month credit note
+    4. villa <-> room lockout       -> booking one side zeroes the other's OTA stock
+
+Re-runnable: it clears its own demo data first. To wipe demo data without
+running the show:  ...execute kamra.scripts.demo_aiosell.reset
+"""
+
+import frappe
+from frappe.utils import add_days, nowdate
+
+from kamra.channels import provider_for
+from kamra.channel_manager import _apply_event, ari_snapshot
+
+DEMO_PROPERTY = "Kamra Lakeside Villa"   # has a real Villa + a member STD
+HOTEL_CODE = "sandbox-pms"
+MEMBER_CODE, MEMBER_RATE = "std", "std-ep"
+VILLA_CODE, VILLA_RATE = "villa", "villa-ep"
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+def _line(c="─"):
+	print(c * 68)
+
+
+def _pick_property(property):
+	if property:
+		return property
+	if frappe.db.exists("Property", DEMO_PROPERTY):
+		return DEMO_PROPERTY
+	rt = frappe.get_all("Room Type",
+	                    filters={"disabled": 0, "room_category": "Villa"},
+	                    fields=["property"], limit=1)
+	if rt:
+		return rt[0].property
+	return frappe.get_all("Room Type", filters={"disabled": 0},
+	                      fields=["property"], limit=1)[0].property
+
+
+def _room_types(property):
+	villa = frappe.get_all("Room Type",
+	                       filters={"property": property, "disabled": 0,
+	                                "room_category": "Villa"},
+	                       pluck="name")
+	member = frappe.get_all("Room Type",
+	                        filters={"property": property, "disabled": 0,
+	                                 "room_category": ("!=", "Villa")},
+	                        pluck="name")
+	return (member[0] if member else None), (villa[0] if villa else None)
+
+
+def _ensure_connection(property):
+	name = frappe.db.get_value("Channel Manager Connection",
+	                           {"property": property, "provider": "AioSell"})
+	if name:
+		conn = frappe.get_doc("Channel Manager Connection", name)
+	else:
+		conn = frappe.get_doc({
+			"doctype": "Channel Manager Connection", "property": property,
+			"provider": "AioSell", "active": 1})
+	conn.active = 1
+	conn.external_property_id = HOTEL_CODE
+	conn.pms_slug = "sample-pms"
+	conn.api_username = "testuser"
+	conn.api_key = "testpass"
+	conn.save(ignore_permissions=True)
+	return conn.name
+
+
+def _ensure_mapping(connection, room_type, room_code, rate_code):
+	name = frappe.db.get_value("Channel Room Mapping",
+	                           {"connection": connection, "room_type": room_type})
+	doc = frappe.get_doc("Channel Room Mapping", name) if name else \
+		frappe.get_doc({"doctype": "Channel Room Mapping",
+		                "connection": connection, "room_type": room_type})
+	doc.external_room_id = room_code
+	doc.external_rate_id = rate_code
+	doc.save(ignore_permissions=True)
+
+
+def _ensure_villa_room(property, villa_rt):
+	"""The villa is one sellable unit - make sure it has a physical room, or its
+	availability is always zero and the lockout can't be shown."""
+	if not villa_rt:
+		return
+	if not frappe.db.exists("Room", {"property": property, "room_type": villa_rt}):
+		frappe.get_doc({
+			"doctype": "Room", "property": property, "room_type": villa_rt,
+			"room_number": "VILLA", "housekeeping_status": "Clean",
+			"occupancy_status": "Vacant"}).insert(ignore_permissions=True)
+
+
+def _webhook(connection, payload):
+	"""Apply an inbound AioSell webhook the way the real endpoint's worker
+	does, but inline so any error is visible during the demo."""
+	conn = frappe.get_doc("Channel Manager Connection", connection)
+	for e in provider_for("AioSell").parse_webhook(conn, payload):
+		_apply_event(conn, e)
+	frappe.db.commit()
+
+
+def _res(ota_ref):
+	rows = frappe.get_all("Reservation", filters={"ota_ref": ota_ref},
+	                      fields=["name", "guest_name", "channel", "status",
+	                              "check_in_date", "check_out_date",
+	                              "amount_after_tax", "room_type"])
+	return rows[0] if rows else None
+
+
+def _avail(property, connection, room_type, date, days=12):
+	for r in ari_snapshot(property, connection, days=days):
+		if r["room_type"] == room_type:
+			for d in r["days"]:
+				if d["date"] == str(date):
+					return d["available"]
+	return None
+
+
+def preview(property=None, days=5):
+	"""Show the OUT direction without live credentials: the exact JSON Kamra
+	would POST to Aiosell's /update (inventory) and /update-rates (rates)."""
+	import json
+	from kamra.channels.aiosell import build_push_bodies
+	frappe.set_user("Administrator")
+	property = _pick_property(property)
+	conn = _ensure_connection(property)
+	member_rt, villa_rt = _room_types(property)
+	_ensure_mapping(conn, member_rt, MEMBER_CODE, MEMBER_RATE)
+	if villa_rt:
+		_ensure_mapping(conn, villa_rt, VILLA_CODE, VILLA_RATE)
+		_ensure_villa_room(property, villa_rt)
+	frappe.db.commit()
+
+	snap = ari_snapshot(property, conn, days=int(days))
+	inv, rates = build_push_bodies(HOTEL_CODE, snap)
+	_line("═")
+	print(f"  OUTBOUND PREVIEW · what Kamra would send Aiosell for {property}")
+	print(f"  (first {days} days · villa lockout already applied)")
+	_line("═")
+	print("POST /api/v2/cm/update/<PMS_SLUG>   (availability)")
+	print(json.dumps({"hotelCode": HOTEL_CODE, "updates": inv}, indent=2))
+	_line()
+	print("POST /api/v2/cm/update-rates/<PMS_SLUG>   (rates)")
+	print(json.dumps({"hotelCode": HOTEL_CODE, "updates": rates}, indent=2))
+	_line("═")
+	print("  This is real data from your rooms/pricing. With live credentials")
+	print("  it POSTs to Aiosell and fans out to every connected OTA.")
+	_line("═")
+	return {"inventory_blocks": len(inv), "rate_blocks": len(rates)}
+
+
+def push_to_sandbox(password, property=None, days=14):
+	"""Push REAL Kamra availability + rates to Aiosell's shared SANDBOX and
+	watch it land on live.aiosell.com.
+
+	Points a Kamra connection at the sandbox hotel, maps Kamra's room types onto
+	the sandbox's OWN room codes (executive, suite) so the numbers are visible,
+	then fires Kamra's real push. Run with the sandbox password:
+	    ...execute kamra.scripts.demo_aiosell.push_to_sandbox --kwargs '{"password":"THE_SANDBOX_PW"}'
+	"""
+	from kamra.channel_manager import push_ari, ari_snapshot
+	from kamra.channels.aiosell import build_push_bodies
+	frappe.set_user("Administrator")
+	property = _pick_property(property)
+	member_rt, villa_rt = _room_types(property)
+
+	name = frappe.db.get_value("Channel Manager Connection",
+	                           {"property": property, "provider": "AioSell"})
+	conn = frappe.get_doc("Channel Manager Connection", name) if name else \
+		frappe.get_doc({"doctype": "Channel Manager Connection",
+		                "property": property, "provider": "AioSell"})
+	conn.active = 1
+	conn.external_property_id = "sandbox-pms"   # the sandbox hotelCode
+	conn.pms_slug = "sample-pms"                # the {pms} slug
+	conn.api_username = "sandboxpms"            # sandbox Basic-auth user
+	conn.api_key = password                     # sandbox Basic-auth password
+	conn.save(ignore_permissions=True)
+
+	reset(property)  # clear demo bookings so availability is clean
+	# map Kamra room types -> the sandbox's own codes so they show on its board
+	sandbox_map = [(member_rt, "executive", "executive-s-ep")]
+	if villa_rt:
+		sandbox_map.append((villa_rt, "suite", "suite-s-ep"))
+	for rt, rc, rp in sandbox_map:
+		if rt:
+			_ensure_mapping(conn.name, rt, rc, rp)
+	frappe.db.commit()
+
+	snap = ari_snapshot(property, conn.name, days=int(days))
+	inv, rates = build_push_bodies("sandbox-pms", snap)
+	_line("═")
+	print(f"  KAMRA → AIOSELL SANDBOX   ({property}, next {days} days)")
+	_line("═")
+	print("Kamra room type  →  sandbox code:")
+	for rt, rc, rp in sandbox_map:
+		if rt:
+			print(f"   {rt}  →  {rc} / {rp}")
+	print(f"\nAbout to send {len(inv)} inventory + {len(rates)} rate blocks "
+	      f"(Kamra's real availability & pricing).")
+	try:
+		res = push_ari(conn.name, days=int(days))
+		print("RESULT:", res)
+		print("\n✅ Sent. Refresh live.aiosell.com (Sandbox PMS · Rates & "
+		      "Inventory) — EXECUTIVE/SUITE now show KAMRA's numbers.")
+	except Exception as e:
+		print("PUSH FAILED:", str(e)[:400])
+		print("If that's a 401/auth error, the sandbox API needs real partner "
+		      "credentials (the dashboard login may not double as API auth) — "
+		      "which is the onboarding step.")
+	_line("═")
+	return {"connection": conn.name, "inventory_blocks": len(inv),
+	        "rate_blocks": len(rates)}
+
+
+def reset(property=None):
+	"""Delete this demo's reservations and credit notes so it can replay clean."""
+	property = _pick_property(property)
+	for r in frappe.get_all("Reservation",
+	                        filters={"ota_ref": ("like", "DEMO-%")}, pluck="name"):
+		try:
+			frappe.delete_doc("Reservation", r, force=1, ignore_permissions=True)
+		except Exception:
+			pass
+	for v in frappe.get_all("Discount Voucher",
+	                        filters={"voucher_code": ("like", "CN-DEMO-%")},
+	                        pluck="name"):
+		try:
+			frappe.delete_doc("Discount Voucher", v, force=1, ignore_permissions=True)
+		except Exception:
+			pass
+	frappe.db.commit()
+	print(f"Demo data cleared for {property}.")
+
+
+# ── the show ────────────────────────────────────────────────────────────────
+
+def run(property=None):
+	frappe.set_user("Administrator")
+	property = _pick_property(property)
+	member_rt, villa_rt = _room_types(property)
+	if not member_rt:
+		print(f"'{property}' has no room type to book - add one first.")
+		return
+
+	_line("═")
+	print(f"  AIOSELL SYNC DEMO   ·   property: {property}")
+	_line("═")
+
+	reset(property)
+	conn = _ensure_connection(property)
+	_ensure_mapping(conn, member_rt, MEMBER_CODE, MEMBER_RATE)
+	if villa_rt:
+		_ensure_mapping(conn, villa_rt, VILLA_CODE, VILLA_RATE)
+		_ensure_villa_room(property, villa_rt)
+	frappe.db.commit()
+	print(f"Setup ready · connection {conn} · member room '{member_rt}'"
+	      + (f" · villa '{villa_rt}'" if villa_rt else " · (no villa room type)"))
+
+	ci, co = add_days(nowdate(), 20), add_days(nowdate(), 22)
+
+	# 1 ── a booking arrives from an OTA
+	_line()
+	print("STEP 1 · A guest books on Goibibo → Aiosell → Kamra")
+	_webhook(conn, {
+		"action": "book", "hotelCode": HOTEL_CODE, "channel": "Goibibo",
+		"bookingId": "DEMO-501", "checkin": str(ci), "checkout": str(co),
+		"specialRequests": "High floor, late check-in", "pah": False,
+		"amount": {"amountAfterTax": 3400, "currency": "INR"},
+		"guest": {"firstName": "Asha", "lastName": "Rao", "phone": "9800000000"},
+		"rooms": [{"roomCode": MEMBER_CODE, "rateplanCode": MEMBER_RATE,
+		           "occupancy": {"adults": 2, "children": 0},
+		           "prices": [{"date": str(ci), "sellRate": 1700},
+		                      {"date": str(add_days(ci, 1)), "sellRate": 1700}]}]})
+	r = _res("DEMO-501")
+	print(f"   → Kamra created reservation {r.name}: {r.guest_name} "
+	      f"({r.channel}), {r.check_in_date}→{r.check_out_date}, ₹{r.amount_after_tax:.0f}")
+	print("   Nobody typed it in. Open Kamra → Today/Reservations to show it.")
+
+	# 2 ── the guest changes dates (full replace)
+	_line()
+	print("STEP 2 · The guest extends the stay (Aiosell sends the new state)")
+	_webhook(conn, {
+		"action": "modify", "hotelCode": HOTEL_CODE, "channel": "Goibibo",
+		"bookingId": "DEMO-501", "checkin": str(ci), "checkout": str(add_days(ci, 4)),
+		"amount": {"amountAfterTax": 6800, "currency": "INR"},
+		"guest": {"firstName": "Asha", "lastName": "Rao"},
+		"rooms": [{"roomCode": MEMBER_CODE, "rateplanCode": MEMBER_RATE,
+		           "occupancy": {"adults": 2, "children": 0},
+		           "prices": [{"date": str(ci), "sellRate": 1700}]}]})
+	r = _res("DEMO-501")
+	print(f"   → Same booking, now {r.check_in_date}→{r.check_out_date}, "
+	      f"₹{r.amount_after_tax:.0f}. Updated automatically.")
+
+	# 3 ── the guest cancels → credit note, no cash refund
+	_line()
+	print("STEP 3 · The guest cancels")
+	frappe.db.set_value("Reservation", r.name, "advance_paid", 6800)
+	frappe.db.commit()
+	_webhook(conn, {"action": "cancel", "hotelCode": HOTEL_CODE,
+	                "channel": "Goibibo", "bookingId": "DEMO-501"})
+	r = _res("DEMO-501")
+	cn = frappe.get_all("Discount Voucher",
+	                    filters={"voucher_code": ("like", "CN-%")},
+	                    fields=["voucher_code", "value", "valid_to"],
+	                    order_by="creation desc", limit=1)
+	print(f"   → Reservation {r.name} is now {r.status}.")
+	if cn:
+		print(f"   → Credit note {cn[0].voucher_code}: ₹{cn[0].value:.0f}, "
+		      f"valid to {cn[0].valid_to} (your no-cash-refund policy).")
+
+	# 4 ── villa <-> room lockout (only if this property has a real villa)
+	if villa_rt:
+		_line()
+		print("STEP 4 · Villa ↔ Room lockout (what Kamra pushes back to OTAs)")
+		d = add_days(nowdate(), 5)
+		before_v = _avail(property, conn, villa_rt, d)
+		before_m = _avail(property, conn, member_rt, d)
+		print(f"   Before: villa={before_v} unit, rooms={before_m} on {d}")
+		_webhook(conn, {
+			"action": "book", "hotelCode": HOTEL_CODE, "channel": "Airbnb",
+			"bookingId": "DEMO-777", "checkin": str(d), "checkout": str(add_days(d, 1)),
+			"amount": {"amountAfterTax": 1700, "currency": "INR"},
+			"guest": {"firstName": "Ravi"},
+			"rooms": [{"roomCode": MEMBER_CODE, "rateplanCode": MEMBER_RATE,
+			           "occupancy": {"adults": 2, "children": 0},
+			           "prices": [{"date": str(d), "sellRate": 1700}]}]})
+		after_v = _avail(property, conn, villa_rt, d)
+		after_m = _avail(property, conn, member_rt, d)
+		print(f"   One room sold → villa={after_v} (locked!), rooms={after_m} on {d}")
+		print("   → The whole-villa listing closes on every OTA the moment one "
+		      "room sells.")
+
+		# reverse direction: book the WHOLE villa → every individual room closes
+		d2 = add_days(nowdate(), 7)
+		print(f"\n   Now the other way — book the ENTIRE villa on {d2}:")
+		print(f"   Before: villa={_avail(property, conn, villa_rt, d2)} unit, "
+		      f"rooms={_avail(property, conn, member_rt, d2)}")
+		_webhook(conn, {
+			"action": "book", "hotelCode": HOTEL_CODE, "channel": "Airbnb",
+			"bookingId": "DEMO-778", "checkin": str(d2), "checkout": str(add_days(d2, 1)),
+			"amount": {"amountAfterTax": 8600, "currency": "INR"},
+			"guest": {"firstName": "Meera"},
+			"rooms": [{"roomCode": VILLA_CODE, "rateplanCode": VILLA_RATE,
+			           "occupancy": {"adults": 4, "children": 0},
+			           "prices": [{"date": str(d2), "sellRate": 8600}]}]})
+		print(f"   Whole villa sold → rooms={_avail(property, conn, member_rt, d2)} "
+		      f"(all locked!), villa={_avail(property, conn, villa_rt, d2)} on {d2}")
+		print("   → Every individual room closes on every OTA the moment the "
+		      "villa sells — no double-booking, either direction.")
+
+	_line("═")
+	print("  DEMO COMPLETE. Re-run any time — it resets itself.")
+	_line("═")
+	return {"property": property, "connection": conn}

--- a/kamra/scripts/demo_aiosell.py
+++ b/kamra/scripts/demo_aiosell.py
@@ -131,7 +131,7 @@ def preview(property=None, days=5):
 	would POST to Aiosell's /update (inventory) and /update-rates (rates)."""
 	import json
 	from kamra.channels.aiosell import build_push_bodies
-	frappe.set_user("Administrator")  # nosemgrep: frappe-set-user -- demo script runs as admin to seed and read demo data; not app runtime
+	frappe.set_user("Administrator")  # nosemgrep: frappe-setuser -- demo script runs as admin to seed and read demo data; not app runtime
 	property = _pick_property(property)
 	conn = _ensure_connection(property)
 	member_rt, villa_rt = _room_types(property)
@@ -170,7 +170,7 @@ def push_to_sandbox(password, property=None, days=14):
 	"""
 	from kamra.channel_manager import push_ari, ari_snapshot
 	from kamra.channels.aiosell import build_push_bodies
-	frappe.set_user("Administrator")  # nosemgrep: frappe-set-user -- demo script runs as admin to seed and read demo data; not app runtime
+	frappe.set_user("Administrator")  # nosemgrep: frappe-setuser -- demo script runs as admin to seed and read demo data; not app runtime
 	property = _pick_property(property)
 	member_rt, villa_rt = _room_types(property)
 
@@ -245,7 +245,7 @@ def reset(property=None):
 # ── the show ────────────────────────────────────────────────────────────────
 
 def run(property=None):
-	frappe.set_user("Administrator")  # nosemgrep: frappe-set-user -- demo script runs as admin to seed and read demo data; not app runtime
+	frappe.set_user("Administrator")  # nosemgrep: frappe-setuser -- demo script runs as admin to seed and read demo data; not app runtime
 	property = _pick_property(property)
 	member_rt, villa_rt = _room_types(property)
 	if not member_rt:

--- a/kamra/tests/test_aiosell.py
+++ b/kamra/tests/test_aiosell.py
@@ -1,0 +1,191 @@
+"""AioSell channel-manager adapter: the wire-format rules this integration
+must not drift from. Pure-function tests - no site, no network - so they run
+fast and pin the exact shapes from aiosell-api-context.md.
+
+The consequence layer (booking creation, credit-note cancel, the write-time
+villa guard) is covered by the reservation/eval suites; here we defend only
+the adapter: webhook parsing, the push-side villa lockout, range collapsing,
+and the credentials-pending gate.
+"""
+
+import unittest
+
+import frappe
+
+from kamra.channels import aiosell
+from kamra.channel_manager import _apply_villa_lockout
+
+
+def _book_payload(rooms, action="book"):
+	return {
+		"action": action, "hotelCode": "sandbox-pms", "channel": "Goibibo",
+		"bookingId": "111222333", "cmBookingId": "AAABBBCCC",
+		"checkin": "2026-08-10", "checkout": "2026-08-12",
+		"specialRequests": "Airport Taxi Required", "pah": False,
+		"amount": {"amountAfterTax": 1204, "amountBeforeTax": 1075,
+		           "tax": 129, "currency": "INR", "commission": None},
+		"guest": {"firstName": "Akshay", "lastName": "Kumar",
+		          "email": "a@k.com", "phone": "9988776655"},
+		"rooms": rooms,
+	}
+
+
+ONE_ROOM = [{"roomCode": "executive", "rateplanCode": "executive-s-ep",
+             "guestName": "Akshay Kumar", "occupancy": {"adults": 1, "children": 0},
+             "prices": [{"date": "2026-08-10", "sellRate": 537.5},
+                        {"date": "2026-08-11", "sellRate": 537.5}]}]
+
+
+class TestParseWebhook(unittest.TestCase):
+	def setUp(self):
+		self.conn = frappe._dict()  # parse_webhook is provider-pure
+
+	def test_single_room_book_maps_every_field(self):
+		e = aiosell.parse_webhook(self.conn, _book_payload(ONE_ROOM))
+		self.assertEqual(len(e), 1)
+		e = e[0]
+		self.assertEqual(e["event"], "book")
+		self.assertEqual(e["booking_id"], "111222333")
+		self.assertEqual(e["ota_ref"], "111222333")  # single room -> bare id
+		self.assertEqual(e["room_type_external_id"], "executive")
+		self.assertEqual(e["external_rate_id"], "executive-s-ep")
+		self.assertEqual(e["check_in"], "2026-08-10")
+		self.assertEqual(e["check_out"], "2026-08-12")
+		self.assertEqual(e["adults"], 1)
+		self.assertEqual(e["total"], 1204)  # tax-inclusive booking total
+		self.assertEqual(e["notes"], "Airport Taxi Required")
+
+	def test_multi_room_book_splits_and_suffixes_ota_ref(self):
+		two = ONE_ROOM + [{"roomCode": "suite", "rateplanCode": "suite-d-cp",
+		                   "occupancy": {"adults": 2, "children": 1},
+		                   "prices": [{"date": "2026-08-10", "sellRate": 900},
+		                              {"date": "2026-08-11", "sellRate": 900}]}]
+		e = aiosell.parse_webhook(self.conn, _book_payload(two))
+		self.assertEqual([x["ota_ref"] for x in e], ["111222333-0", "111222333-1"])
+		# multi-room: per-room total is the sum of its nightly sell rates
+		self.assertEqual(e[1]["total"], 1800)
+		self.assertEqual(e[1]["room_type_external_id"], "suite")
+
+	def test_modify_is_flagged_modify(self):
+		e = aiosell.parse_webhook(self.conn, _book_payload(ONE_ROOM, "modify"))
+		self.assertEqual(e[0]["event"], "modify")
+
+	def test_cancel_needs_only_booking_id(self):
+		e = aiosell.parse_webhook(self.conn, {
+			"action": "cancel", "hotelCode": "sandbox-pms",
+			"channel": "Goibibo", "bookingId": "111222333"})
+		self.assertEqual(len(e), 1)
+		self.assertEqual(e[0]["event"], "cancel")
+		self.assertEqual(e[0]["booking_id"], "111222333")
+		self.assertEqual(e[0]["ota_ref"], "111222333")
+
+	def test_missing_guest_never_crashes(self):
+		p = _book_payload([{"roomCode": "executive", "rateplanCode": "x",
+		                    "occupancy": {"adults": 2, "children": 0}}])
+		p["guest"] = {}
+		e = aiosell.parse_webhook(self.conn, p)[0]
+		self.assertEqual(e["guest_name"], "OTA Guest")
+		self.assertEqual(e["phone"], "")
+
+
+class TestVillaLockout(unittest.TestCase):
+	def _rows(self, villa_av, std_av):
+		return [
+			{"room_type": "VILLA", "days": [{"date": "d1", "available": villa_av, "rate": 0}]},
+			{"room_type": "STD", "days": [{"date": "d1", "available": std_av, "rate": 0}]},
+		]
+
+	META = {"VILLA": {"category": "Villa", "total": 1},
+	        "STD": {"category": "Private", "total": 3}}
+
+	def test_all_free_is_untouched(self):
+		rows = self._rows(1, 3)
+		_apply_villa_lockout(rows, self.META)
+		self.assertEqual(rows[0]["days"][0]["available"], 1)
+		self.assertEqual(rows[1]["days"][0]["available"], 3)
+
+	def test_a_booked_member_room_zeroes_the_villa(self):
+		rows = self._rows(1, 2)  # one std room sold
+		_apply_villa_lockout(rows, self.META)
+		self.assertEqual(rows[0]["days"][0]["available"], 0)  # villa locked
+		self.assertEqual(rows[1]["days"][0]["available"], 2)  # std unchanged
+
+	def test_a_booked_villa_zeroes_every_member(self):
+		rows = self._rows(0, 3)  # villa sold
+		_apply_villa_lockout(rows, self.META)
+		self.assertEqual(rows[0]["days"][0]["available"], 0)
+		self.assertEqual(rows[1]["days"][0]["available"], 0)  # std locked
+
+	def test_no_villa_mapped_is_a_noop(self):
+		rows = self._rows(1, 2)
+		meta = {"VILLA": {"category": "Private", "total": 1},
+		        "STD": {"category": "Private", "total": 3}}
+		_apply_villa_lockout(rows, meta)
+		self.assertEqual(rows[0]["days"][0]["available"], 1)
+		self.assertEqual(rows[1]["days"][0]["available"], 2)
+
+
+class TestRangeCollapse(unittest.TestCase):
+	def test_consecutive_equal_values_collapse_to_ranges(self):
+		runs = aiosell._runs([{"date": "d1", "value": 5},
+		                      {"date": "d2", "value": 5},
+		                      {"date": "d3", "value": 3}])
+		self.assertEqual(runs, [["d1", "d2", 5], ["d3", "d3", 3]])
+
+
+class _StubConn:
+	def __init__(self, live):
+		self.endpoint = None
+		if live:
+			self.api_username, self._pw = "realuser", "realpw"
+			self.pms_slug, self.external_property_id = "sample-pms", "sandbox-pms"
+		else:
+			self.api_username, self._pw = "<USERNAME>", "<PASSWORD>"
+			self.pms_slug, self.external_property_id = "<PMS_SLUG>", "sandbox-pms"
+
+	def get_password(self, *a, **k):
+		return self._pw
+
+
+class TestPush(unittest.TestCase):
+	def test_placeholder_credentials_report_pending_not_a_fake_sync(self):
+		ok, detail = aiosell.push_ari(_StubConn(live=False), [])
+		self.assertFalse(ok)
+		self.assertIn("pending", detail.lower())
+
+	def test_push_bodies_match_the_spec_shapes(self):
+		captured = []
+
+		def fake_post(conn, path, payload, user, pwd):
+			captured.append((path, payload))
+			return True, {"success": True, "message": "ok"}
+
+		orig = aiosell._post
+		aiosell._post = fake_post
+		try:
+			snapshot = [{"room_type": "STD", "external_room_id": "executive",
+			             "external_rate_id": "executive-s-ep",
+			             "days": [{"date": "2026-08-10", "available": 5, "rate": 1749},
+			                      {"date": "2026-08-11", "available": 5, "rate": 1749}]}]
+			ok, _ = aiosell.push_ari(_StubConn(live=True), snapshot)
+		finally:
+			aiosell._post = orig
+
+		self.assertTrue(ok)
+		paths = {p for p, _ in captured}
+		self.assertEqual(paths, {"update/sample-pms", "update-rates/sample-pms"})
+		bodies = dict(captured)
+		inv = bodies["update/sample-pms"]
+		self.assertEqual(inv["hotelCode"], "sandbox-pms")
+		room = inv["updates"][0]["rooms"][0]
+		self.assertEqual(room, {"roomCode": "executive", "available": 5})
+		# two equal days collapsed into one inclusive range
+		self.assertEqual(inv["updates"][0]["startDate"], "2026-08-10")
+		self.assertEqual(inv["updates"][0]["endDate"], "2026-08-11")
+		rate = bodies["update-rates/sample-pms"]["updates"][0]["rates"][0]
+		self.assertEqual(rate, {"roomCode": "executive",
+		                        "rateplanCode": "executive-s-ep", "rate": 1749})
+
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
Aiosell channel-manager two-way sync

Wires Kamra ↔ Aiosell so OTA bookings flow in and availability/rates flow out.

Inbound webhook — book / modify / cancel create/replace/cancel reservations; cancel issues a 6-month credit note (no cash refund).
Outbound push — availability + rates pushed to Aiosell (hourly, on booking, on rate change).
Villa ↔ Room lockout — booking the whole villa closes all its rooms (and vice-versa), across the front desk and the OTA push.
Adapter (channels/aiosell.py) does protocol only; all logic lives in channel_manager.py.
Credentials/{pms} stay as placeholders until partner onboarding.
Testing: 12 unit tests (tests/test_aiosell.py), a one-command demo (scripts/demo_aiosell.py), and sandbox-verified push. Full flow documented in aiosell-channel-manager-flow.md.

