### PR TITLE
fix(channel-manager): preserve AioSell Basic-auth so Frappe doesn't r…

### DIFF
--- a/kamra/channels/aiosell.py
+++ b/kamra/channels/aiosell.py
@@ -238,10 +238,39 @@ def _connection_for(hotel_code: str):
 	return frappe.get_doc("Channel Manager Connection", name) if name else None
 
 
+WEBHOOK_PATH = "/api/method/kamra.channels.aiosell.reservation_webhook"
+
+
+def preserve_webhook_auth():
+	"""`before_request` hook (runs BEFORE Frappe's own auth check).
+
+	Frappe reserves the `Authorization: Basic` header for its own api-key login
+	and rejects anything that isn't a valid Frappe key - before allow_guest
+	endpoints run. AioSell authenticates its webhook with Basic auth (the
+	partner username/password we set), which is NOT a Frappe api key, so Frappe
+	would 401 the call before our webhook ever sees it.
+
+	For our webhook path only, stash the header and strip it from the request so
+	Frappe treats the call as guest; reservation_webhook then validates the
+	stashed credentials itself against the Channel Manager Connection."""
+	req = getattr(frappe.local, "request", None)
+	if not req or getattr(req, "path", None) != WEBHOOK_PATH:
+		return
+	auth = req.headers.get("Authorization")
+	if auth and auth.startswith("Basic "):
+		frappe.local.flags.aiosell_webhook_auth = auth
+		# request.headers is read-only; drop it from the WSGI environ so
+		# frappe.get_request_header("Authorization") returns None downstream.
+		req.environ.pop("HTTP_AUTHORIZATION", None)
+
+
 def _auth_ok(conn) -> bool:
 	"""Constant-time-validate the inbound Basic-auth header against the
-	connection's stored credentials."""
-	header = frappe.get_request_header("Authorization") if frappe.request else None
+	connection's stored credentials. Reads the header preserved by
+	preserve_webhook_auth (Frappe strips it during its own auth), falling back
+	to the live header for direct calls / tests."""
+	header = getattr(frappe.local.flags, "aiosell_webhook_auth", None) \
+		or (frappe.get_request_header("Authorization") if frappe.request else None)
 	if not header or not header.startswith("Basic "):
 		return False
 	try:

--- a/kamra/hooks.py
+++ b/kamra/hooks.py
@@ -290,7 +290,9 @@ doc_events["Reservation"] = {
 
 # Request Events
 # ----------------
-# before_request = ["kamra.utils.before_request"]
+# Preserve AioSell's Basic-auth header for the channel webhook before Frappe's
+# own api-key auth rejects it (see kamra.channels.aiosell.preserve_webhook_auth).
+before_request = ["kamra.channels.aiosell.preserve_webhook_auth"]
 # after_request = ["kamra.utils.after_request"]
 
 # Job Events


### PR DESCRIPTION
AioSell webhook Basic-auth rejected by Frappe's auth layer

Frappe reserves the Authorization: Basic header for its own API-key login and rejects any Basic auth that isn't a valid Frappe key — before allow_guest endpoints run. AioSell authenticates its webhook with Basic auth (the partner username/password we configure), which isn't a Frappe API key, so Frappe returned AuthenticationError before our webhook code ever executed.

Fix:

 -Added a before_request hook (preserve_webhook_auth) — runs before Frappe's auth check. For the webhook path only, it stashes the Authorization header and strips it from the request, so Frappe treats the call as guest instead of rejecting it.
 -Updated _auth_ok to read the stashed header and validate it against the Channel Manager Connection.
Result: AioSell's Basic-auth credentials now authenticate on the webhook — no need to force the credentials to be Frappe API keys.

Files: kamra/channels/aiosell.py, kamra/hooks.py