### PR TITLE
fix(channel-manager): OTA cancel under Guest + agent_name logging

### DIFF
--- a/kamra/api.py
+++ b/kamra/api.py
@@ -2441,7 +2441,10 @@ def _do_cancel(res, reason: str = "Guest request", note: str | None = None,
 	res.cancelled_on = frappe.utils.now_datetime()
 	frappe.flags.kamra_cancelling = True
 	try:
-		res.save()
+		# ignore_permissions: both callers are pre-authorized — the desk wrapper
+		# via @require_roles, the OTA webhook worker as a trusted internal caller
+		# (it runs as Guest). Validation (villa lockout etc.) still runs.
+		res.save(ignore_permissions=True)
 	finally:
 		frappe.flags.kamra_cancelling = False
 

--- a/kamra/kamra/doctype/agent_action_log/agent_action_log.json
+++ b/kamra/kamra/doctype/agent_action_log/agent_action_log.json
@@ -36,8 +36,7 @@
    "fieldname": "agent_name",
    "fieldtype": "Data",
    "in_list_view": 1,
-   "label": "Agent Name",
-   "reqd": 1
+   "label": "Agent Name"
   },
   {
    "fieldname": "actor",


### PR DESCRIPTION
## What & why
Two runtime bugs found while testing the Aiosell channel-manager flow on ewa.kamrapms.com. Incoming OTA bookings work, but:

### 1. OTA cancel silently failed
The webhook worker runs as the **Guest** user. `_do_cancel` saved the reservation with a plain `res.save()` (no `ignore_permissions`), so Guest hit a `PermissionError`, the job rolled back, and the cancel never applied — even though the webhook returned `success: true`.

**Fix:** `res.save(ignore_permissions=True)`. Safe for both callers — the desk cancel is already authorized via `@require_roles`, and the webhook is a trusted internal caller. Validation (villa lockout, etc.) still runs.

### 2. Savings-ledger writes failing on every action
The `Agent Action Log` doctype marked `agent_name` as required (`reqd: 1`), but `log_action` intentionally leaves it null for non-agent (human/system/channel) actions. So every booking, cancel, and rate-push failed to write its ledger row and spammed the Error Log with "Agent Action Log write failed" (non-fatal, but noisy and no audit trail).

**Fix:** dropped `reqd` on `agent_name`.

## Verification
- Both confirmed directly from the ewa Error Log tracebacks.
- Audited the full webhook path (book / modify / cancel, fee posting, credit-note voucher, folio addons) — no other writes are missing `ignore_permissions`.
- Book & modify paths were already correct.

