### PR TITLE
fix(pos): restore Esc and Maximize on floor fullscreen

### DIFF
--- a/frontend/src/lib/kiosk.ts
+++ b/frontend/src/lib/kiosk.ts
@@ -1,6 +1,6 @@
 /** Till / kitchen pass: hide PMS chrome and fill the viewport. */
 
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react"
 
 const EVENT = "kamra:kiosk"
 
@@ -32,5 +32,70 @@ export function useKiosk(auto = false) {
     enter: () => setKiosk(true),
     exit: () => setKiosk(false),
     toggle: () => setKiosk(!on),
+  }
+}
+
+/**
+ * Floor screens (POS / Kitchen): auto-hide PMS chrome, optional browser
+ * fullscreen, and Escape restores chrome (and exits browser FS).
+ *
+ * Maximize toggles browser fullscreen only — it must not flip kiosk off,
+ * which previously brought the sidebar/header back while still "on" the floor.
+ */
+export function useFloorFullscreen(
+  rootRef: RefObject<HTMLElement | null>,
+  options?: { blockEscape?: () => boolean },
+) {
+  const kiosk = useKiosk(true)
+  const [browserFs, setBrowserFs] = useState(
+    () => typeof document !== "undefined" && !!document.fullscreenElement,
+  )
+  // Keep the latest gate without re-binding Escape on every parent render.
+  const blockEscapeRef = useRef(options?.blockEscape)
+  blockEscapeRef.current = options?.blockEscape
+
+  useEffect(() => {
+    const onFs = () => setBrowserFs(!!document.fullscreenElement)
+    document.addEventListener("fullscreenchange", onFs)
+    return () => document.removeEventListener("fullscreenchange", onFs)
+  }, [])
+
+  const exitFloor = useCallback(() => {
+    if (document.fullscreenElement) void document.exitFullscreen()
+    setKiosk(false)
+  }, [])
+
+  const toggleBrowserFs = useCallback(() => {
+    if (document.fullscreenElement) {
+      void document.exitFullscreen()
+      return
+    }
+    setKiosk(true)
+    void rootRef.current?.requestFullscreen?.()
+  }, [rootRef])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return
+      if (blockEscapeRef.current?.()) return
+      const el = e.target as HTMLElement | null
+      if (el?.closest?.("input, textarea, select, [contenteditable=true]")) return
+      // Clear kiosk so chrome returns in one keypress (without navigating away).
+      // Also exit browser FS ourselves — preventDefault can stop the native exit.
+      if (!document.fullscreenElement && !kiosk.on) return
+      e.preventDefault()
+      exitFloor()
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [exitFloor, kiosk.on])
+
+  return {
+    kioskOn: kiosk.on,
+    browserFs,
+    /** Chrome hidden or browser fullscreen — layout fills the viewport. */
+    floorOn: kiosk.on || browserFs,
+    toggleBrowserFs,
+    exitFloor,
   }
 }

--- a/frontend/src/lib/kiosk.ts
+++ b/frontend/src/lib/kiosk.ts
@@ -77,7 +77,12 @@ export function useFloorFullscreen(
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return
-      if (blockEscapeRef.current?.()) return
+      if (blockEscapeRef.current?.()) {
+        // Overlay owns this Escape (e.g. ticket drawer). Stop the browser from
+        // also leaving fullscreen so layers unwind one at a time.
+        if (document.fullscreenElement) e.preventDefault()
+        return
+      }
       const el = e.target as HTMLElement | null
       if (el?.closest?.("input, textarea, select, [contenteditable=true]")) return
       // Clear kiosk so chrome returns in one keypress (without navigating away).

--- a/frontend/src/screens/Kitchen.tsx
+++ b/frontend/src/screens/Kitchen.tsx
@@ -558,7 +558,9 @@ export default function Kitchen() {
   // back to the board rather than stranding the chef on a dead ticket.
   const open = openOrder ? orders.find((o) => o.name === openOrder) : undefined
   useEffect(() => {
-    if (openOrder && orders.length && !open) setOpenOrder(null)
+    // Clear even when the queue empties — requiring orders.length left a stale
+    // openOrder that blocked Escape from exiting kiosk with no drawer visible.
+    if (openOrder && !open) setOpenOrder(null)
   }, [openOrder, orders, open])
 
   return (

--- a/frontend/src/screens/Kitchen.tsx
+++ b/frontend/src/screens/Kitchen.tsx
@@ -8,7 +8,7 @@ import { subscribeRealtime } from "../lib/realtime"
 import { Button } from "../components/ui/button"
 import { cn } from "../lib/utils"
 import { cur } from "../lib/money"
-import { useKiosk } from "../lib/kiosk"
+import { useFloorFullscreen } from "../lib/kiosk"
 
 type LineState = "cooking" | "held" | "cancelled" | "done"
 
@@ -483,21 +483,13 @@ export default function Kitchen() {
   const [busy, setBusy] = useState<string | null>(null)
   const [openOrder, setOpenOrder] = useState<string | null>(null)
   const [sound, setSound] = useState(() => localStorage.getItem(CHIME_KEY) !== "off")
-  const kiosk = useKiosk(true)
   const rootRef = useRef<HTMLDivElement>(null)
-  const [browserFs, setBrowserFs] = useState(false)
+  const openOrderRef = useRef<string | null>(null)
+  openOrderRef.current = openOrder
+  const { kioskOn, browserFs, toggleBrowserFs } = useFloorFullscreen(rootRef, {
+    blockEscape: () => !!openOrderRef.current,
+  })
   const now = useNow()
-
-  useEffect(() => {
-    const onFs = () => setBrowserFs(!!document.fullscreenElement)
-    document.addEventListener("fullscreenchange", onFs)
-    return () => document.removeEventListener("fullscreenchange", onFs)
-  }, [])
-
-  function toggleBrowserFs() {
-    if (document.fullscreenElement) document.exitFullscreen()
-    else rootRef.current?.requestFullscreen?.()
-  }
 
   useEffect(() => {
     call<{ name: string; outlet_name: string }[]>("kamra.pos.outlets", { property: getCurrentProperty() })
@@ -572,7 +564,7 @@ export default function Kitchen() {
   return (
     <div ref={rootRef} className={cn(
       "flex h-full min-h-0 flex-col bg-zinc-100",
-      kiosk.on && "p-0",
+      kioskOn && "p-0",
     )}>
     <div className={cn("flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-3 transition-[padding] duration-200",
       open && "sm:pr-[calc(50vw+1rem)]")}>
@@ -606,7 +598,7 @@ export default function Kitchen() {
           </button>
           <button onClick={toggleBrowserFs}
             className="rounded-lg border border-zinc-300 bg-white p-2 text-zinc-600 hover:bg-zinc-50"
-            title={browserFs ? "Exit browser full screen" : "Browser full screen"}>
+            title={browserFs ? "Exit full screen (Esc)" : "Browser full screen"}>
             {browserFs ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
           </button>
           <button onClick={load} aria-label="Refresh"><RefreshCw className="size-5 text-zinc-400" /></button>

--- a/frontend/src/screens/POS.tsx
+++ b/frontend/src/screens/POS.tsx
@@ -8,7 +8,7 @@ import { call, getCurrentProperty } from "../lib/api"
 import { subscribeRealtime } from "../lib/realtime"
 import { serverError } from "../lib/resource"
 import { printThermal, kotHtml, billHtml, type BillData, type KotLine } from "../lib/thermal"
-import { useKiosk } from "../lib/kiosk"
+import { useFloorFullscreen } from "../lib/kiosk"
 import { Button } from "../components/ui/button"
 import { cur, moneyLocale } from "../lib/money"
 
@@ -199,8 +199,7 @@ export default function POS() {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [printNote, setPrintNote] = useState<string | null>(null)
-  const kiosk = useKiosk(true)
-  const [full, setFull] = useState(false)
+  const { floorOn, browserFs, toggleBrowserFs } = useFloorFullscreen(rootRef)
 
   useEffect(() => {
     call<Outlet[]>("kamra.pos.outlets", { property: getCurrentProperty() })
@@ -209,9 +208,6 @@ export default function POS() {
     call<{ rooms: { name: string; room_number: string }[] }>("kamra.api.hk_queue", { property: getCurrentProperty() })
       .then((d) => setRooms(d.rooms || []))
       .catch(() => {})
-    const onFs = () => setFull(!!document.fullscreenElement)
-    document.addEventListener("fullscreenchange", onFs)
-    return () => document.removeEventListener("fullscreenchange", onFs)
   }, [])
 
   useEffect(() => { localStorage.setItem("pos_print_kot", printKot ? "1" : "0") }, [printKot])
@@ -434,15 +430,6 @@ export default function POS() {
     }))
   }
 
-  function toggleFull() {
-    if (kiosk.on || document.fullscreenElement) {
-      if (document.fullscreenElement) document.exitFullscreen()
-      kiosk.exit()
-    } else {
-      kiosk.enter()
-      rootRef.current?.requestFullscreen?.()
-    }
-  }
   async function saveNc(undo = false) {
     if (!selected) return
     await act(async () => {
@@ -565,7 +552,6 @@ export default function POS() {
       : [[null, visibleTables]]
 
   const isNewCustomerType = !selected && (orderType === "Takeaway" || orderType === "Delivery")
-  const floorOn = kiosk.on || full
   const runningBills = open.filter((o) => !o.kot_fired)
   const kitchenBills = open.filter((o) => o.kot_fired && o.pending > 0)
 
@@ -596,10 +582,10 @@ export default function POS() {
                 (printKot ? "border-brand-600 bg-brand-50 text-brand-800" : "border-zinc-300 bg-white text-zinc-500")}>
               <Printer className="size-3.5" />{printKot ? "KOT printer on" : "KOT printer off"}
             </button>
-            <button onClick={toggleFull}
+            <button onClick={toggleBrowserFs}
               className="rounded-lg border border-zinc-300 bg-white p-2 text-zinc-600 hover:bg-zinc-50"
-              title={floorOn ? "Exit full screen" : "Full screen till"}>
-              {floorOn ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
+              title={browserFs ? "Exit full screen (Esc)" : "Full screen till"}>
+              {browserFs ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
             </button>
             <Button onClick={() => newOrder()}>
               <Plus className="size-4" />New Bill


### PR DESCRIPTION
## Summary
- Fix POS/Kitchen floor mode so Maximize enters browser fullscreen instead of flipping kiosk off and bringing the sidebar/header back
- Make Esc exit browser fullscreen and restore PMS chrome without navigating away
- Share one `useFloorFullscreen` helper used by Restaurant POS and Kitchen Display (KOT tickets)

## Test plan
- [ ] Open `/pos` — sidebar/header hidden by default
- [ ] Click Maximize — browser fullscreen; chrome stays hidden (does not flash back)
- [ ] Press Esc — leave fullscreen and restore sidebar/header without leaving the page
- [ ] Click Maximize again after Esc — kiosk + browser fullscreen return
- [ ] Open `/kitchen` — same Maximize / Esc behavior
- [ ] On Kitchen with a ticket drawer open, Esc closes the drawer first; second Esc restores chrome


Made with [Cursor](https://cursor.com)