### PR TITLE
chore: sync main into develop after release train

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,10 +1,11 @@
 name: release-please
 
 # Stable-release automation. Every push to main updates (or opens) a
-# "Release PR" that bumps kamra/__init__.py and drafts the CHANGELOG entry
-# from Conventional Commit messages. Merging that PR tags vX.Y.Z and
-# publishes the GitHub Release; artifact publishing (Docker image, demo
-# deploy) then runs via the reusable Release workflow below.
+# draft "Release PR" that bumps kamra/__init__.py and drafts the CHANGELOG
+# entry from Conventional Commit messages. Keep it draft until you intend to
+# ship — merging that PR tags vX.Y.Z and publishes the GitHub Release; artifact
+# publishing (Docker image, demo deploy) then runs via the reusable Release
+# workflow below.
 #
 # NOTE: the tag is created with GITHUB_TOKEN, and GitHub deliberately does
 # NOT fire `on: push: tags` workflows for such tags — that's why release.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,22 @@ and `npm run dev` in `frontend/` for the SPA.
   `develop`) and hotfixes land here; the Frappe Cloud Marketplace listing and
   demo.kamrapms.com track its releases.
 
+### Branch naming
+
+One short prefix, kebab-case slug. Prefer these over free-form names
+(`property_management`, `azzaxp/…`, `feature/…`):
+
+| Prefix | Use for | Version impact when released |
+|---|---|---|
+| `feat/<slug>` | New user-facing capability | **MINOR** (`feat:`) |
+| `fix/<slug>` | Bug fix on `develop` | **PATCH** (`fix:`) |
+| `hotfix/<slug>` | Urgent fix branched from `main` | **PATCH** (`fix:`) |
+| `chore/<slug>` | Tooling, CI, deps, housekeeping | none by itself |
+| `docs/<slug>` | Docs / listing copy only | none by itself |
+
+Delete the remote branch after the PR merges — leave `main`, `develop`, and
+any still-open work only.
+
 See [`RELEASING.md`](RELEASING.md) for the full release process.
 
 ## Before you open a PR
@@ -43,9 +59,16 @@ chore: bump frontend deps
 BREAKING CHANGE: removes the `Foo` doctype; see CHANGELOG.
 ```
 
-Commit messages aren't just style here: release automation
+Pick the prefix carefully — release automation
 ([release-please](https://github.com/googleapis/release-please)) derives the
-next version number and the changelog draft from them.
+next version and the changelog draft from them:
+
+- **`fix:`** — everyday bugfixes and small corrections (PATCH). Prefer this
+  whenever the change is not a new capability.
+- **`feat:`** — only for real, user-visible additions (MINOR). Do not mark a
+  small fix or polish pass as `feat:` just to “feel like a feature”.
+- **`chore:` / `docs:` / `ci:` / `test:`** — no version bump by themselves.
+- **`BREAKING CHANGE:`** footer (or `feat!:` / `fix!:`) — MAJOR.
 
 ## Versioning & releases
 
@@ -56,12 +79,17 @@ Kamra follows [Semantic Versioning](https://semver.org/):
 - **MINOR** — new features, additive/backward-compatible doctype changes.
 - **PATCH** — fixes with no migration impact.
 
-Releases are automated: merging a release train from `develop` into `main`
-makes release-please open (or update) a **Release PR** with the version bump
-and the [`CHANGELOG.md`](CHANGELOG.md) draft compiled from Conventional
-Commits; merging that PR tags `vX.Y.Z`, publishes the GitHub Release and the
-`ghcr.io/kamra-pms/kamra` Docker image, and redeploys demo.kamrapms.com.
-The full runbook lives in [`RELEASING.md`](RELEASING.md).
+**Cadence:** land work on `develop` (nightly). Cut a stable release only when
+you are ready to ship to the marketplace / demo — typically a monthly train,
+or when a feature set is actually ready. Bugfixes can wait on `develop` and
+ship together as one PATCH (or ride along in the next MINOR). Do **not** merge
+the Release PR for every small merge into `main`; leave it open (it stays a
+draft) until you intend to tag and build.
+
+Merging a release train from `develop` into `main` updates the draft Release
+PR with the version bump and [`CHANGELOG.md`](CHANGELOG.md) notes; merging
+that Release PR is what tags `vX.Y.Z`, publishes GitHub + Docker, and
+redeploys demo.kamrapms.com. Full runbook: [`RELEASING.md`](RELEASING.md).
 
 If your change removes or renames anything a self-hoster might depend on
 (a doctype, a whitelisted method, a config key), call it out explicitly under

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,15 +12,18 @@ The maintainer runbook. Contributors don't need this — see
 
 ## The normal release train (monthly, or when a feature set is ready)
 
+Ship stable versions deliberately. Nightly already tracks `develop` — most
+fixes do **not** need a new `vX.Y.Z` the same day.
+
 1. **Merge the train:** open a PR `develop` → `main` titled
    `chore: release train YYYY-MM`, wait for CI, merge (merge commit, not
    squash — keeps individual Conventional Commits visible to release-please).
-2. **Review the Release PR:** release-please opens/updates
-   `chore(main): release X.Y.Z` on `main` with the version bump
-   (`kamra/__init__.py`) and the CHANGELOG draft. Edit the changelog prose in
-   that PR if the auto-generated wording needs polish — hand-curated notes are
-   part of the product.
-3. **Merge the Release PR.** Automation takes it from there:
+2. **Leave the Release PR as a draft until you mean to publish.** release-please
+   opens/updates a draft `chore(main): release X.Y.Z` on `main` with the
+   version bump (`kamra/__init__.py`) and the CHANGELOG draft. You can merge
+   several trains/hotfixes into `main` and let that draft accumulate. Mark it
+   ready and edit the changelog prose only when you intend to tag.
+3. **Merge the Release PR** when you are ready to ship. Automation then:
    tag `vX.Y.Z` → GitHub Release → Docker image → demo redeploy.
 4. **Frappe Cloud Marketplace** (manual, ~2 min): dashboard →
    Apps → kamra → create a release from the new `main` state and submit for
@@ -28,11 +31,24 @@ The maintainer runbook. Contributors don't need this — see
 5. **Announce:** release thread on discuss.frappe.io; anything else
    (X/LinkedIn) as warranted.
 
+### What bumps what
+
+| Commit prefix on `main` | Next tag | When to use |
+|---|---|---|
+| `fix:` | PATCH (`2.6.0` → `2.6.1`) | Bugfixes, small corrections |
+| `feat:` | MINOR (`2.6.0` → `2.7.0`) | Real user-facing additions only |
+| `BREAKING CHANGE` / `feat!:` | MAJOR | Rare; migrate-breaking |
+
+Prefer `fix:` for polish and regressions. A month of fixes should usually be
+one PATCH (or ride along in the next MINOR), not a string of MINORs.
+
 ## Hotfix path (stable is broken, develop has moved on)
 
 1. Branch from `main`: `git checkout -b hotfix/<slug> main`.
 2. Fix with a `fix:` commit, PR into `main`, merge after CI.
-3. Merge the resulting Release PR (PATCH bump) — ships automatically.
+3. **Only merge the Release PR if production needs the tag now.** Otherwise
+   leave the draft Release PR open so the PATCH can ship with the next
+   intentional cut. Marketplace / demo rebuild when the Release PR merges.
 4. **Port back:** cherry-pick the fix onto `develop` (or merge `main` into
    `develop`) so the next train doesn't regress it.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "simple",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
+  "draft-pull-request": true,
   "packages": {
     ".": {
       "package-name": "kamra",


### PR DESCRIPTION
## Summary
- Sync \`main\` → \`develop\` after the release train content (#52 OTA cancel, #53 floor fullscreen) landed on \`main\`
- Also carries #55 (draft Release PRs / slower version cadence)

## Test plan
- [ ] CI green
- [ ] \`develop\` matches \`main\` tip after merge


Made with [Cursor](https://cursor.com)