### PR TITLE
docs: customer tenants track main, not develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,14 @@ your property, then add staff users.
 
 | Kamra | Frappe | Channel |
 |---|---|---|
-| `main` releases (`vX.Y.Z`) | v16 | **stable** — Frappe Cloud Marketplace, `ghcr.io/kamra-pms/kamra:latest`, [demo.kamrapms.com](https://demo.kamrapms.com) |
-| `develop` | v16 | **nightly** — `ghcr.io/kamra-pms/kamra:nightly`, rebuilt every night |
+| `main` releases (`vX.Y.Z`) | v16 | **stable** — Marketplace, `ghcr.io/kamra-pms/kamra:latest`, [demo.kamrapms.com](https://demo.kamrapms.com), **customer tenants** (e.g. [ewa.kamrapms.com](https://ewa.kamrapms.com)) |
+| `develop` | v16 | **nightly** — `ghcr.io/kamra-pms/kamra:nightly`, [nightly.kamrapms.com](https://nightly.kamrapms.com) |
 
-`develop` is the repo's default branch (for contributors), so production
-installs should keep the explicit `--branch main`. Releases follow
-[SemVer](https://semver.org/); see [`RELEASING.md`](RELEASING.md).
+`develop` is the default branch for contributors. **Production and customer
+sites always track `main`** (`bench get-app … --branch main`). Releases follow
+[SemVer](https://semver.org/); see [`RELEASING.md`](RELEASING.md). Version tags
+only move when a Release PR is deliberately merged — small fixes can wait on
+`main` as a draft PATCH.
 
 ## Quickstart (development)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,6 +9,7 @@ The maintainer runbook. Contributors don't need this — see
 |---|---|---|---|
 | **nightly** | `develop` | nightly.kamrapms.com, `ghcr.io/kamra-pms/kamra:nightly`, rolling `nightly` prerelease | every night at 03:00 IST, if develop moved and CI is green |
 | **stable** | `main` + tag `vX.Y.Z` | GitHub Release, `ghcr.io/kamra-pms/kamra:<tag>` + `:latest`, demo.kamrapms.com, Frappe Cloud Marketplace | when a Release PR is merged |
+| **tenants** | `main` tip (or a tag) | Customer sites (e.g. ewa.kamrapms.com) via `kamra-deploy/update-tenant.sh` | after a release train lands on `main`; do **not** point tenants at `develop` |
 
 ## The normal release train (monthly, or when a feature set is ready)
 


### PR DESCRIPTION
## Summary
- README + RELEASING: customer tenants (Ewa) track **main**; develop is nightly only
- Points at \`kamra-deploy/update-tenant.sh\` for tenant redeploys

## Test plan
- [ ] Docs read cleanly; channels table matches deploy practice


Made with [Cursor](https://cursor.com)