### PR TITLE
fix(folio): return guest_id for nationality edit

### DIFF
--- a/kamra/api.py
+++ b/kamra/api.py
@@ -1548,6 +1548,7 @@ def _invoice_guest(res) -> dict:
 		["full_name", "phone", "email", "nationality", "address_line",
 		 "city", "id_type", "id_number"], as_dict=True) or {}
 	return {
+		"guest_id": res.guest,
 		"name": g.get("full_name") or res.guest_name,
 		"phone": g.get("phone"), "email": g.get("email"),
 		"nationality": g.get("nationality"),


### PR DESCRIPTION
## Summary
- Adds `guest_id` to `_invoice_guest` / `folio_invoice` so the folio nationality editor can save
- Without this, FolioView never renders the edit control (`guest_id` was gated)

Related to #59 / #60

## Test plan
- [ ] Open an open folio → Nationality row shows with **edit**
- [ ] Save a new nationality → persists on reload and GRC


Made with [Cursor](https://cursor.com)