### PR TITLE
feat: enhance phone input handling and validation in BookingDialog; a…

### DIFF
--- a/frontend/src/components/BookingDialog.tsx
+++ b/frontend/src/components/BookingDialog.tsx
@@ -13,6 +13,13 @@ import {
 } from "../lib/api"
 import { Button } from "./ui/button"
 import { cur, moneyLocale } from "../lib/money"
+import {
+  clampLocal,
+  isPhoneComplete,
+  joinPhone,
+  phoneLengthForDial,
+  splitPhone,
+} from "../lib/phone"
 
 interface ExtraRoom {
   room_type: string
@@ -25,6 +32,62 @@ const inputCls =
   "w-full rounded-lg border border-zinc-300 bg-white px-3.5 py-2.5 text-base " +
   "focus:outline-2 focus:outline-offset-1 focus:outline-brand-600"
 
+/**
+ * Phone entry with the property's dial code shown as a fixed prefix, so staff
+ * type only the local number. `value`/`onChange` stay fully qualified
+ * (`+919148869914`) - the prefix is presentation, not a separate field.
+ */
+function PhoneInput(props: {
+  value: string
+  country?: string | null
+  onChange: (phone: string) => void
+  placeholder?: string
+}) {
+  const { dial, local } = splitPhone(props.value, props.country)
+  const { min, max } = phoneLengthForDial(dial)
+  // only nag once they have stopped short - not on every keystroke of a
+  // number they are still typing
+  const short = local.length > 0 && local.length < min
+  return (
+    <>
+      <div
+        className={
+          "flex items-center gap-1.5 rounded-lg border bg-white pl-3.5 " +
+          "focus-within:outline-2 focus-within:outline-offset-1 " +
+          (short
+            ? "border-rose-300 focus-within:outline-rose-500"
+            : "border-zinc-300 focus-within:outline-brand-600")
+        }
+      >
+        <span className="shrink-0 text-base text-zinc-500">+{dial}</span>
+        <input
+          type="tel"
+          inputMode="numeric"
+          maxLength={max}
+          className="w-full min-w-0 bg-transparent py-2.5 pr-3.5 text-base focus:outline-none"
+          value={local}
+          // clamp rather than trust maxLength: it does not apply to paste in
+          // every browser, and autofill bypasses it entirely
+          onChange={(e) =>
+            props.onChange(joinPhone(dial, clampLocal(e.target.value, dial)))
+          }
+          placeholder={props.placeholder ?? "91488 69914"}
+        />
+        <span className="shrink-0 pr-3.5 text-xs tabular-nums text-zinc-400">
+          {local.length}/{max}
+        </span>
+      </div>
+      {short && (
+        <p className="mt-1.5 text-xs text-rose-600">
+          {min === max
+            ? `+${dial} numbers are ${min} digits.`
+            : `+${dial} numbers are ${min}-${max} digits.`}
+        </p>
+      )}
+    </>
+  )
+}
+
 function Field(props: { label: string; children: React.ReactNode }) {
   return (
     <label className="block">
@@ -36,6 +99,13 @@ function Field(props: { label: string; children: React.ReactNode }) {
   )
 }
 
+
+function todayLocal() {
+  const d = new Date()
+  const m = `${d.getMonth() + 1}`.padStart(2, "0")
+  const day = `${d.getDate()}`.padStart(2, "0")
+  return `${d.getFullYear()}-${m}-${day}`
+}
 
 const inr = (n: number) =>
   n.toLocaleString(moneyLocale(), { maximumFractionDigits: 0 })
@@ -156,6 +226,16 @@ export function BookingDialog(props: {
     d.setDate(d.getDate() + Math.max(1, form.nights))
     return d.toISOString().slice(0, 10)
   })()
+
+  // a new booking cannot start in the past - the input's `min` is advisory
+  // only (typed and pasted values bypass it), so gate the submit too
+  const pastCheckIn = form.check_in_date < todayLocal()
+
+  // phone is optional, but a half-typed one is a data-entry slip, not a choice
+  const country = options?.property?.country
+  const badPhone =
+    !isPhoneComplete(form.phone, country) ||
+    (onBehalf && !isPhoneComplete(form.booked_by_phone, country))
 
   useEffect(() => {
     if (!form.room_type) return
@@ -568,11 +648,10 @@ export function BookingDialog(props: {
                     )}
                   </Field>
                   <Field label="Phone">
-                    <input
-                      className={inputCls}
+                    <PhoneInput
                       value={form.phone}
-                      onChange={(e) => set("phone", e.target.value)}
-                      placeholder="+91 …"
+                      country={options?.property?.country}
+                      onChange={(v) => set("phone", v)}
                     />
                   </Field>
                 </div>
@@ -607,9 +686,15 @@ export function BookingDialog(props: {
                     <input
                       type="date"
                       className={inputCls}
+                      min={todayLocal()}
                       value={form.check_in_date}
                       onChange={(e) => set("check_in_date", e.target.value)}
                     />
+                    {pastCheckIn && (
+                      <p className="mt-1.5 text-xs text-rose-600">
+                        That date has already passed.
+                      </p>
+                    )}
                   </Field>
                   <Field label="Nights">
                     <input
@@ -909,13 +994,12 @@ export function BookingDialog(props: {
                                   />
                                 </Field>
                                 <Field label="Booker phone">
-                                  <input
-                                    className={inputCls}
+                                  <PhoneInput
                                     value={form.booked_by_phone}
-                                    onChange={(e) =>
-                                      set("booked_by_phone", e.target.value)
+                                    country={options?.property?.country}
+                                    onChange={(v) =>
+                                      set("booked_by_phone", v)
                                     }
-                                    placeholder="+91 …"
                                   />
                                 </Field>
                               </div>
@@ -1207,7 +1291,7 @@ export function BookingDialog(props: {
               <div className="shrink-0 space-y-2 border-t border-zinc-200 bg-white px-6 py-4 md:px-7">
                 <Button
                   className="w-full justify-center py-2.5 text-base"
-                  disabled={busy || !form.guest_name || !quote}
+                  disabled={busy || !form.guest_name || !quote || pastCheckIn || badPhone}
                   onClick={() => submit()}
                 >
                   {busy ? "Booking…" : "Confirm booking"}
@@ -1223,7 +1307,7 @@ export function BookingDialog(props: {
                   <Button
                     variant="outline"
                     className="justify-center"
-                    disabled={busy || !form.guest_name}
+                    disabled={busy || !form.guest_name || pastCheckIn || badPhone}
                     onClick={() => submit(true)}
                     title="Park this stay with no room; promote when inventory frees"
                   >

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -256,6 +256,7 @@ export interface BookingOptions {
     cancellation_fee: "None" | "First Night" | "Full Stay"
     no_show_charge: "None" | "First Night" | "Full Stay"
     deposit_pct: number
+    country: string
   }
 }
 

--- a/frontend/src/lib/phone.ts
+++ b/frontend/src/lib/phone.ts
@@ -1,25 +1,223 @@
 /** Format property/host phone numbers for guest-facing pages.
  *  Always include an international dial code so guests can tap-to-call. */
 
+/**
+ * Country (or ISO code) to international dial code. Keys are lower-cased and
+ * matched exactly, so common spellings and emirate/city names guests actually
+ * write get their own alias - "dubai" must not fall through to the default.
+ */
 const DIAL_BY_COUNTRY: Record<string, string> = {
+  // India and neighbours
   india: "91",
   in: "91",
+  nepal: "977",
+  np: "977",
+  "sri lanka": "94",
+  lk: "94",
+  bangladesh: "880",
+  bd: "880",
+  maldives: "960",
+  mv: "960",
+  bhutan: "975",
+  bt: "975",
+  pakistan: "92",
+  pk: "92",
+
+  // Gulf - the emirates are commonly written in place of the country
   "united arab emirates": "971",
   uae: "971",
+  "u.a.e.": "971",
+  emirates: "971",
   ae: "971",
+  dubai: "971",
+  "abu dhabi": "971",
+  sharjah: "971",
+  "saudi arabia": "966",
+  ksa: "966",
+  sa: "966",
+  qatar: "974",
+  qa: "974",
+  oman: "968",
+  om: "968",
+  kuwait: "965",
+  kw: "965",
+  bahrain: "973",
+  bh: "973",
+
+  // Americas
   "united states": "1",
   usa: "1",
   us: "1",
+  "united states of america": "1",
+  canada: "1",
+  ca: "1",
+  mexico: "52",
+  mx: "52",
+  brazil: "55",
+  br: "55",
+
+  // Europe
   "united kingdom": "44",
   uk: "44",
   gb: "44",
+  england: "44",
+  ireland: "353",
+  ie: "353",
+  germany: "49",
+  de: "49",
+  france: "33",
+  fr: "33",
+  italy: "39",
+  it: "39",
+  spain: "34",
+  es: "34",
+  portugal: "351",
+  pt: "351",
+  netherlands: "31",
+  nl: "31",
+  belgium: "32",
+  be: "32",
+  switzerland: "41",
+  ch: "41",
+  austria: "43",
+  at: "43",
+  sweden: "46",
+  se: "46",
+  norway: "47",
+  no: "47",
+  denmark: "45",
+  dk: "45",
+  poland: "48",
+  pl: "48",
+  greece: "30",
+  gr: "30",
+  russia: "7",
+  ru: "7",
+  turkey: "90",
+  tr: "90",
+
+  // Asia-Pacific
+  china: "86",
+  cn: "86",
+  "hong kong": "852",
+  hk: "852",
+  japan: "81",
+  jp: "81",
+  "south korea": "82",
+  kr: "82",
+  thailand: "66",
+  th: "66",
+  malaysia: "60",
+  my: "60",
+  indonesia: "62",
+  id: "62",
+  vietnam: "84",
+  vn: "84",
+  philippines: "63",
+  ph: "63",
   singapore: "65",
   sg: "65",
   australia: "61",
   au: "61",
+  "new zealand": "64",
+  nz: "64",
+
+  // Africa and Middle East
+  "south africa": "27",
+  za: "27",
+  kenya: "254",
+  ke: "254",
+  egypt: "20",
+  eg: "20",
+  mauritius: "230",
+  mu: "230",
+  israel: "972",
+  il: "972",
 }
 
-function dialForCountry(country?: string | null): string {
+/**
+ * National-number digit counts per dial code, for the countries above.
+ * A range covers countries where landline and mobile differ in length
+ * (UK landlines run 9-10 digits, UAE 8-9); most are a single fixed length.
+ * Counts exclude the dial code and any trunk "0".
+ */
+const LENGTH_BY_DIAL: Record<string, { min: number; max: number }> = {
+  // South Asia
+  "91": { min: 10, max: 10 }, // India
+  "977": { min: 8, max: 10 }, // Nepal - 8 landline, 10 mobile
+  "94": { min: 9, max: 9 }, // Sri Lanka
+  "880": { min: 9, max: 10 }, // Bangladesh
+  "960": { min: 7, max: 7 }, // Maldives
+  "975": { min: 8, max: 8 }, // Bhutan
+  "92": { min: 10, max: 10 }, // Pakistan
+
+  // Gulf
+  "971": { min: 8, max: 9 }, // UAE - incl. Dubai, Abu Dhabi
+  "966": { min: 9, max: 9 }, // Saudi Arabia
+  "974": { min: 8, max: 8 }, // Qatar
+  "968": { min: 8, max: 8 }, // Oman
+  "965": { min: 8, max: 8 }, // Kuwait
+  "973": { min: 8, max: 8 }, // Bahrain
+
+  // Americas
+  "1": { min: 10, max: 10 }, // US / Canada
+  "52": { min: 10, max: 10 }, // Mexico
+  "55": { min: 10, max: 11 }, // Brazil
+
+  // Europe
+  "44": { min: 9, max: 10 }, // UK
+  "353": { min: 7, max: 9 }, // Ireland
+  "49": { min: 6, max: 11 }, // Germany - unusually variable
+  "33": { min: 9, max: 9 }, // France
+  "39": { min: 9, max: 11 }, // Italy
+  "34": { min: 9, max: 9 }, // Spain
+  "351": { min: 9, max: 9 }, // Portugal
+  "31": { min: 9, max: 9 }, // Netherlands
+  "32": { min: 8, max: 9 }, // Belgium
+  "41": { min: 9, max: 9 }, // Switzerland
+  "43": { min: 7, max: 13 }, // Austria - unusually variable
+  "46": { min: 7, max: 9 }, // Sweden
+  "47": { min: 8, max: 8 }, // Norway
+  "45": { min: 8, max: 8 }, // Denmark
+  "48": { min: 9, max: 9 }, // Poland
+  "30": { min: 10, max: 10 }, // Greece
+  "7": { min: 10, max: 10 }, // Russia / Kazakhstan
+  "90": { min: 10, max: 10 }, // Turkey
+
+  // Asia-Pacific
+  "86": { min: 10, max: 11 }, // China
+  "852": { min: 8, max: 8 }, // Hong Kong
+  "81": { min: 9, max: 10 }, // Japan
+  "82": { min: 9, max: 10 }, // South Korea
+  "66": { min: 8, max: 9 }, // Thailand
+  "60": { min: 9, max: 10 }, // Malaysia
+  "62": { min: 9, max: 12 }, // Indonesia
+  "84": { min: 9, max: 9 }, // Vietnam
+  "63": { min: 10, max: 10 }, // Philippines
+  "65": { min: 8, max: 8 }, // Singapore
+  "61": { min: 9, max: 9 }, // Australia
+  "64": { min: 8, max: 10 }, // New Zealand
+
+  // Africa and Middle East
+  "27": { min: 9, max: 9 }, // South Africa
+  "254": { min: 9, max: 9 }, // Kenya
+  "20": { min: 10, max: 10 }, // Egypt
+  "230": { min: 7, max: 8 }, // Mauritius
+  "972": { min: 9, max: 9 }, // Israel
+}
+
+/** E.164 caps a full number at 15 digits, so an unlisted code gets the slack. */
+const DEFAULT_LENGTH = { min: 4, max: 15 }
+
+/** How many digits the local part may have, for a given dial code. */
+export function phoneLengthForDial(dial: string): { min: number; max: number } {
+  const spec = LENGTH_BY_DIAL[dial]
+  if (spec) return spec
+  const room = 15 - dial.length
+  return { min: DEFAULT_LENGTH.min, max: Math.min(DEFAULT_LENGTH.max, room) }
+}
+
+export function dialForCountry(country?: string | null): string {
   const key = (country || "India").trim().toLowerCase()
   return DIAL_BY_COUNTRY[key] || "91"
 }
@@ -80,4 +278,59 @@ export function formatPhoneTel(
     local = local.slice(dial.length)
   }
   return `+${dial}${local}`
+}
+
+/**
+ * Split a stored number into its dial code and the local part, for inputs that
+ * render the code as a fixed prefix. Falls back to the property's country when
+ * the stored value carries no code of its own.
+ */
+export function splitPhone(
+  phone: string | null | undefined,
+  country?: string | null,
+): { dial: string; local: string } {
+  const dial = dialForCountry(country)
+  const raw = (phone || "").trim()
+  if (!raw) return { dial, local: "" }
+  if (raw.startsWith("+")) {
+    // joinPhone always writes a leading "+", so the code here is unambiguous
+    // even mid-typing: "+919" is a 1-digit local number, not "919".
+    const digits = digitsOnly(raw.slice(1))
+    return {
+      dial,
+      local: digits.startsWith(dial) ? digits.slice(dial.length) : digits,
+    }
+  }
+  // stored without a code: only strip one that sits in front of a full local
+  // number, since a 10-digit Indian number can itself start with "91"
+  const digits = digitsOnly(raw)
+  if (digits.length > 10 && digits.startsWith(dial)) {
+    return { dial, local: digits.slice(dial.length) }
+  }
+  return { dial, local: digits }
+}
+
+/** Recombine a prefixed input back into storage form, e.g. `+919148869914`. */
+export function joinPhone(dial: string, local: string): string {
+  const digits = digitsOnly(local)
+  return digits ? `+${dial}${digits}` : ""
+}
+
+/** Trim a local part to the most digits its country allows. */
+export function clampLocal(local: string, dial: string): string {
+  return digitsOnly(local).slice(0, phoneLengthForDial(dial).max)
+}
+
+/**
+ * Is this a complete number for its country? Empty counts as valid: phone is
+ * optional on a booking, so only a half-typed number should block anything.
+ */
+export function isPhoneComplete(
+  phone: string | null | undefined,
+  country?: string | null,
+): boolean {
+  const { dial, local } = splitPhone(phone, country)
+  if (!local) return true
+  const { min, max } = phoneLengthForDial(dial)
+  return local.length >= min && local.length <= max
 }

--- a/frontend/src/screens/Banquet.tsx
+++ b/frontend/src/screens/Banquet.tsx
@@ -751,6 +751,7 @@ function EnquirySheet({
             <input
               type="date"
               className={inputCls}
+              min={today()}
               value={form.event_date}
               onChange={(e) => set("event_date", e.target.value)}
             />
@@ -759,6 +760,7 @@ function EnquirySheet({
             <input
               type="date"
               className={inputCls}
+              min={form.event_date || today()}
               value={form.end_date}
               onChange={(e) => set("end_date", e.target.value)}
             />
@@ -816,6 +818,11 @@ function EnquirySheet({
           </p>
           {avail === null ? (
             <p className="text-sm text-zinc-400">Checking…</p>
+          ) : avail.length === 0 ? (
+            <p className="text-sm text-zinc-500">
+              No halls set up for this property yet — add one under Halls &amp;
+              Venues.
+            </p>
           ) : (
             <div className="grid gap-2 sm:grid-cols-2">
               {avail.map((v) => {

--- a/kamra/api.py
+++ b/kamra/api.py
@@ -3113,7 +3113,7 @@ def _booking_property_policy(property: str) -> dict:
 	prop = frappe.db.get_value(
 		"Property", property,
 		["sell_message", "free_cancel_days", "cancellation_fee",
-		 "no_show_charge", "deposit_pct"],
+		 "no_show_charge", "deposit_pct", "country"],
 		as_dict=True,
 	) or {}
 	prop["cancellation_fee"] = prop.get("cancellation_fee") or "None"
@@ -3121,6 +3121,8 @@ def _booking_property_policy(property: str) -> dict:
 	prop["free_cancel_days"] = int(prop.get("free_cancel_days") or 0)
 	prop["deposit_pct"] = float(prop.get("deposit_pct") or 0)
 	prop["sell_message"] = prop.get("sell_message") or ""
+	# drives the dial-code prefix on guest phone inputs
+	prop["country"] = prop.get("country") or "India"
 	return prop
 
 

--- a/kamra/kamra/doctype/reservation/reservation.py
+++ b/kamra/kamra/doctype/reservation/reservation.py
@@ -4,7 +4,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cint, date_diff, now_datetime
+from frappe.utils import cint, date_diff, formatdate, now_datetime, today
 
 
 class Reservation(Document):
@@ -86,6 +86,7 @@ class Reservation(Document):
 
 	def validate(self):
 		self.validate_dates()
+		self.validate_past_check_in()
 		self.nights = date_diff(self.check_out_date, self.check_in_date)
 		self.validate_minimum_nights()
 		self.validate_status_transition()
@@ -176,6 +177,24 @@ class Reservation(Document):
 				frappe.throw(_("Day-use stays check out the same day."))
 		elif diff < 1:
 			frappe.throw(_("Check-out must be after check-in."))
+
+	def validate_past_check_in(self):
+		"""A new booking cannot start before today (property timezone).
+
+		Only new documents are checked: existing stays must stay editable once
+		their check-in has passed, and back-dated entry (walk-in caught up
+		after the fact, historical import) sets flags.allow_past_check_in.
+		"""
+		if not self.is_new() or self.flags.get("allow_past_check_in"):
+			return
+		if self.status in ("Cancelled", "No Show", "Checked In", "Checked Out"):
+			return
+		if date_diff(today(), self.check_in_date) > 0:
+			frappe.throw(
+				_("Check-in {0} has already passed. Pick today or a later date.")
+				.format(formatdate(self.check_in_date)),
+				title=_("Check-in date is in the past"),
+			)
 
 	def validate_blacklist(self):
 		if not self.guest or not self.is_new():

--- a/kamra/scripts/eval_harness.py
+++ b/kamra/scripts/eval_harness.py
@@ -180,13 +180,18 @@ def _guest(name, phone):
 	}).insert(ignore_permissions=True).name
 
 
-def _res(guest, ci, co, room=None, day_use=0):
-	return frappe.get_doc({
+def _res(guest, ci, co, room=None, day_use=0, allow_past=0):
+	doc = frappe.get_doc({
 		"doctype": "Reservation", "property": P, "guest": guest,
 		"room_type": RT, "room": room, "check_in_date": ci,
 		"check_out_date": co, "adults": 2, "is_day_use": day_use,
 		"auto_price": 1,
-	}).insert(ignore_permissions=True)
+	})
+	# a back-dated booking (e.g. seeding a no-show) is a legitimate case the
+	# past-check-in guard exempts via this flag
+	if allow_past:
+		doc.flags.allow_past_check_in = True
+	return doc.insert(ignore_permissions=True)
 
 
 @check("double booking blocked; adjacent stay allowed")
@@ -498,7 +503,7 @@ def t18():
 
 	# yesterday's un-arrived booking → no-show flagged AND charged
 	g3 = _guest("Eval NoShow", "+91 70000 00017")
-	ns = _res(g3, add_days(nowdate(), -1), nowdate())
+	ns = _res(g3, add_days(nowdate(), -1), nowdate(), allow_past=1)
 	run_night_audit(P, nowdate())
 	assert frappe.db.get_value("Reservation", ns.name, "status") == "No Show"
 	ns_folio = frappe.db.get_value(


### PR DESCRIPTION

## What & why
Two validation improvements on the booking side to prevent bad data at entry.

### 1. Guest phone input validation
The phone field in the booking dialog now validates the number and shows the correct **country dial-code prefix**, driven by the property's country.
- New `frontend/src/lib/phone.ts` helper (dial codes + formatting/validation)
- Wired into `BookingDialog.tsx`
- `_booking_property_policy` now returns the property's `country` to drive the prefix (`api.py`, `api.ts`)

### 2. Block past-dated check-ins
A check-in date before today can no longer be entered.
- **Frontend:** past dates are blocked in the booking dialog and the banquet enquiry date pickers
- **Backend:** `Reservation.validate_past_check_in()` rejects a past check-in on new bookings even via the API — with an `allow_past_check_in` flag for legitimate cases (walk-ins caught up after the fact, historical imports). Existing/cancelled/checked-in/out stays are unaffected.

