### PR TITLE
fix(reservation): block backdated check-in on create and amend

### DIFF
--- a/docs-site/user-guide.md
+++ b/docs-site/user-guide.md
@@ -24,7 +24,9 @@ board, refreshed every 30 seconds.
 1. Type the guest's name — returning guests appear as you type; picking
    one attaches the stay to their profile ("Returning guest · 4 stays").
 2. Pick room type, dates, occupancy, meal plan. The **quote updates live**
-   and states the cancellation policy and any deposit expected.
+   and states the cancellation policy and any deposit expected. Check-in
+   cannot be before today (unless recording a past stay via import or an
+   explicit catch-up flag).
 3. **Add another room** turns the booking into a group — one confirm
    books every room under one group reference.
 4. Optional: company (bills corporate — see billing rules), travel

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -24,7 +24,9 @@ board, refreshed every 30 seconds.
 1. Type the guest's name — returning guests appear as you type; picking
    one attaches the stay to their profile ("Returning guest · 4 stays").
 2. Pick room type, dates, occupancy, meal plan. The **quote updates live**
-   and states the cancellation policy and any deposit expected.
+   and states the cancellation policy and any deposit expected. Check-in
+   cannot be before today (unless recording a past stay via import or an
+   explicit catch-up flag).
 3. **Add another room** turns the booking into a group — one confirm
    books every room under one group reference.
 4. Optional: company (bills corporate — see billing rules), travel

--- a/frontend/src/screens/ReservationDetail.tsx
+++ b/frontend/src/screens/ReservationDetail.tsx
@@ -163,6 +163,14 @@ function IdentityCard({ d, reload }: { d: Detail; reload: () => void }) {
   )
 }
 
+function todayLocal() {
+  const d = new Date()
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, "0")
+  const day = String(d.getDate()).padStart(2, "0")
+  return `${y}-${m}-${day}`
+}
+
 export default function ReservationDetail({
   row,
   reload,
@@ -320,6 +328,13 @@ export default function ReservationDetail({
               <input
                 type="date"
                 value={ci}
+                min={
+                  // keep existing past check-in visible for in-house stays,
+                  // but do not allow amending into an earlier past date
+                  d.check_in_date && d.check_in_date < todayLocal()
+                    ? d.check_in_date
+                    : todayLocal()
+                }
                 disabled={!d.actions.can_amend}
                 onChange={(e) => setCi(e.target.value)}
                 className="mt-0.5 w-full rounded-lg border border-zinc-300 bg-white px-2 py-1.5 text-sm disabled:bg-zinc-50 disabled:text-zinc-400"

--- a/kamra/kamra/doctype/reservation/reservation.py
+++ b/kamra/kamra/doctype/reservation/reservation.py
@@ -179,22 +179,32 @@ class Reservation(Document):
 			frappe.throw(_("Check-out must be after check-in."))
 
 	def validate_past_check_in(self):
-		"""A new booking cannot start before today (property timezone).
+		"""Check-in cannot be before calendar today for sellable stays.
 
-		Only new documents are checked: existing stays must stay editable once
-		their check-in has passed, and back-dated entry (walk-in caught up
-		after the fact, historical import) sets flags.allow_past_check_in.
+		- New bookings with a past check-in are rejected.
+		- Edits that *change* check-in to a past date are rejected (so desk
+		  cannot quietly backdate Confirmed / Held / Checked In stays).
+		- Saving an in-house stay without changing dates stays allowed —
+		  arrival already happened, the nights are historical.
+		- Cancelled / No Show are exempt (not inventoriable).
+		- Walk-in catch-up, seeding, and imports set flags.allow_past_check_in
+		  (or ignore_validate on history import).
 		"""
-		if not self.is_new() or self.flags.get("allow_past_check_in"):
+		if self.flags.get("allow_past_check_in"):
 			return
-		if self.status in ("Cancelled", "No Show", "Checked In", "Checked Out"):
+		if self.status in ("Cancelled", "No Show"):
 			return
-		if date_diff(today(), self.check_in_date) > 0:
-			frappe.throw(
-				_("Check-in {0} has already passed. Pick today or a later date.")
-				.format(formatdate(self.check_in_date)),
-				title=_("Check-in date is in the past"),
-			)
+		if date_diff(today(), self.check_in_date) <= 0:
+			return
+		if not self.is_new():
+			old = self.get_doc_before_save()
+			if old and date_diff(old.check_in_date, self.check_in_date) == 0:
+				return
+		frappe.throw(
+			_("Check-in {0} has already passed. Pick today or a later date.")
+			.format(formatdate(self.check_in_date)),
+			title=_("Check-in date is in the past"),
+		)
 
 	def validate_blacklist(self):
 		if not self.guest or not self.is_new():

--- a/kamra/scripts/eval_harness.py
+++ b/kamra/scripts/eval_harness.py
@@ -513,6 +513,40 @@ def t18():
 	assert any("No-show" in (c.description or "") for c in charges)
 
 
+@check("past check-in blocked on create and on date amend; allow_past still works")
+def t18b():
+	g = _guest("Eval PastCI", "+91 70000 00018")
+	yesterday = add_days(nowdate(), -1)
+	# new booking into the past must fail
+	try:
+		_res(g, yesterday, nowdate())
+		raise AssertionError("past check-in accepted on create")
+	except frappe.ValidationError:
+		pass
+	# flag still allows catch-up / seeding
+	res = _res(g, yesterday, nowdate(), allow_past=1)
+	# saving without changing dates (in-house style) must stay ok
+	res.status = "Checked In"
+	res.save(ignore_permissions=True)
+	# moving check-in further into the past must fail
+	res.check_in_date = add_days(nowdate(), -2)
+	try:
+		res.save(ignore_permissions=True)
+		raise AssertionError("past check-in amend accepted")
+	except frappe.ValidationError:
+		pass
+	# Confirmed stay: amend check-in to yesterday must fail
+	g2 = _guest("Eval PastCI2", "+91 70000 00028")
+	live = _res(g2, add_days(nowdate(), 2), add_days(nowdate(), 3))
+	live.check_in_date = yesterday
+	live.check_out_date = nowdate()
+	try:
+		live.save(ignore_permissions=True)
+		raise AssertionError("Confirmed past amend accepted")
+	except frappe.ValidationError:
+		pass
+
+
 @check("closed folio is frozen: charges immutable, payments still settle")
 def t19():
 	from kamra import api


### PR DESCRIPTION
## Summary
- Tighten `Reservation.validate_past_check_in` so past check-in is rejected on **create** and when **amending** check-in into the past
- Leave unchanged past dates alone (in-house stays can still save)
- Keep `flags.allow_past_check_in` and Cancelled / No Show exemptions
- Reservation detail date picker uses `min` so UI matches the rule
- Eval harness coverage + user-guide note

Closes #71

## Test plan
- [ ] New reservation with yesterday’s check-in → error
- [ ] Edit Confirmed: move check-in to yesterday → error
- [ ] Checked In: save without changing dates → ok
- [ ] Checked In: move check-in further into the past → error
- [ ] `allow_past_check_in` / history import → still succeeds
- [ ] Booking dialog / public book still reject past check-in


Made with [Cursor](https://cursor.com)