### PR TITLE
docs: refresh README for the 2.6.2 / Unreleased train

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 
 ## Contents
 
+- [What's new](#whats-new)
 - [Why Kamra](#why-kamra)
 - [What makes it different](#what-makes-it-different)
 - [Screenshots](#screenshots)
@@ -45,6 +46,23 @@
 - [Quickstart (development)](#quickstart-development)
 - [Who it's for](#who-its-for)
 - [License & contributors](#license--contributors)
+
+---
+
+## What's new
+
+On **`develop`** (nightly) the product is the **2.6.2** train plus Unreleased
+work. The `v2.6.2` GitHub tag is still pending — latest published release is
+[v2.6.0](https://github.com/Kamra-PMS/kamra-pms/releases/tag/v2.6.0).
+
+- **Unreleased** — System Health, property time zone, **85 MCP tools** (role +
+  module gated), AI provider presets, WordPress-easy `deploy/install.sh`,
+  banquet Phase 1 (send quote, guest response, Sales/Finance/HK/F&B checklists)
+- **2.6.2** (in the changelog; not tagged yet) — Opera-style cashier till,
+  folio ledger, cashier PIN, POS full-screen till
+
+Notes live in [`CHANGELOG.md`](CHANGELOG.md) — this list is a pointer, not a
+second release note. How we cut stables: [`RELEASING.md`](RELEASING.md).
 
 ---
 
@@ -66,7 +84,7 @@ Kamra is the alternative we wanted:
 
 ## What makes it different
 
-- **Agent-ready, not agent-locked.** [MCP server](https://kamrapms.com/docs/ai-and-mcp) with 50+ governed tools — role-scoped, permission-checked, fully logged. Connect Claude; no bundled agent to trust.
+- **Agent-ready, not agent-locked.** [MCP server](https://kamrapms.com/docs/ai-and-mcp) with **85** governed tools — role-scoped, module-gated, permission-checked, fully logged. Connect Claude; no bundled agent to trust.
 - **Bring your own key.** No AI markup or model lock-in. Optional [HeyKoala](https://heykoala.ai) for voice / WhatsApp concierge.
 - **Deterministic money.** Rates, tax slabs, availability, and no-overbooking guards come from code — never from a language model.
 - **Full audit trail.** Every human or AI action: who, what, why.
@@ -123,13 +141,13 @@ Live example: [demo.kamrapms.com/book](https://demo.kamrapms.com/book).
 | **Short-term rentals** | Hotel vs STR property kind, sellable units, per-villa locations, Instant / Request-to-book |
 | **Booking** | Multi-room / group / corporate, returning guests, add-ons, vouchers, travel agents, day-use |
 | **Revenue** | Seasons, rate plans, guardrails, hurdle rates, overbooking allowance, cancellation & no-show policy in code |
-| **Billing** | Folios, corporate routing, group masters, charge splits, night audit, tax invoices, GSTR-1, payment links |
-| **F&B** | POS table map, split bills, thermal KOT, kitchen display, inventory & recipes, QR ordering, room posting |
-| **Operations** | Tickets + SLA, housekeeping `/hk`, guest laundry end-to-end, lost & found, banquet / events |
+| **Billing** | Folios, corporate routing, group masters, charge splits, night audit, tax invoices, GSTR-1, payment links, cashier till (FO+POS cash, PIN pad), folio ledger |
+| **F&B** | POS table map, full-screen till and kitchen pass, split bills, thermal KOT, kitchen display, inventory & recipes, QR ordering, room posting |
+| **Operations** | Tickets + SLA, housekeeping `/hk`, guest laundry end-to-end, lost & found, banquet / events (send quote, guest response, dept checklists) |
 | **Guests** | Online pre-check-in, GRC + occupant register, **editable nationality**, ID retention modes |
 | **Messaging** | WhatsApp (Meta Cloud API) — confirmations, check-in links, inbox, desk tickets |
 | **Localization** | India GST, Indonesia PB1, Thailand VAT, Malaysia SST, UAE VAT — currency & locales follow the pack |
-| **Platform** | Multi-property RBAC, dark mode, CSV migration (eZee / Cloudbeds presets), eval harness in CI |
+| **Platform** | Multi-property RBAC, dark mode, property time zone, System Health, AI provider presets, CSV migration (eZee / Cloudbeds presets), eval harness in CI |
 
 ---
 

--- a/docs-site/features.md
+++ b/docs-site/features.md
@@ -47,9 +47,12 @@ amount; route lines between Guest/Company/Group folios (alcohol can never
 reach a company folio); night audit that posts room nights idempotently
 and charges no-shows per policy; GST invoices with per-property series;
 allowances, part-settlement, invoice cancellation with a register;
-**GSTR-1 export** in Tally / Zoho Books / ERPNext formats. To run full
-company books (and optional HR) on the same Frappe site as Kamra, see
-[ERPNext and Frappe HR](/self-hosting/erpnext-hr).
+**GSTR-1 export** in Tally / Zoho Books / ERPNext formats. **Cashier** is
+Opera-style: till open/close with float and variance, unified FO+POS cash,
+petty cash, a shift report, currency desk, and a PIN pad on folio and POS
+money actions. Folios use an append-only ledger (Guest / Deposit / AR /
+Package). To run full company books (and optional HR) on the same Frappe
+site as Kamra, see [ERPNext and Frappe HR](/self-hosting/erpnext-hr).
 
 ## Your country's taxes
 
@@ -79,7 +82,8 @@ in-house guests also raise a Service Ticket on the desk queue.
 ## F&B — POS and kitchen
 
 Outlet-based restaurant POS with a photo menu, per-item instructions and
-guest discounts. The captain works from a colour-coded **table map**
+guest discounts, plus a **full-screen till and kitchen pass**. The captain
+works from a colour-coded **table map**
 (vacant / running / in kitchen / ready) and can juggle several running
 bills at once — dine-in, room service, takeaway and delivery (with the
 customer's name, phone and address carried onto the KOT and bill). A table holds **any
@@ -191,6 +195,11 @@ you say so.
 play, outstanding — with conversion, a breakdown by event type, hall
 and source, and why the business that went away went away.
 
+**Phase 1 ops.** Send the quotation by email or WhatsApp, record the
+guest's response on the desk (no guest portal), and on Confirm fan out
+department checklists — Sales, Finance, HK, F&B — plus a quote
+no-response chase.
+
 ## Direct bookings
 
 A public booking page with live availability and real quotes, photo
@@ -238,7 +247,16 @@ one.
 
 ## AI & audit
 
-An MCP server with 85 governed tools, one-click Connect Claude, an in-app
-copilot (bring your own key), rate guardrails agents cannot price outside,
-deterministic pricing verified by an automated eval suite, and an activity
-ledger recording every action — human or AI — with who, what and why.
+An MCP server with 85 governed tools (filtered by user roles **and** the
+property's enabled modules), one-click Connect Claude, an in-app copilot
+with Settings presets (OpenAI, Gemini, Groq, OpenRouter, Ollama), rate
+guardrails agents cannot price outside, deterministic pricing verified by
+an automated eval suite, and an activity ledger recording every action —
+human or AI — with who, what and why.
+
+## Admin
+
+**System Health** (Admin) checks the installed version against GitHub,
+runs site diagnostics, and points at the upgrade path for self-host /
+bench / Docker — no auto-upgrade. Property **time zone** lives on Admin →
+Settings → Property and syncs the site clock on single-property sites.

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -33,8 +33,8 @@ features:
 
 ## What is Kamra?
 
-::: tip New — short-term rentals
-Kamra 2.5 runs villa portfolios as well as hotels. [Read the announcement](https://kamrapms.com/updates/short-term-rentals/) · try the [demo booking page](https://demo.kamrapms.com/book).
+::: tip What's new on develop
+The **2.6.2** train (GitHub tag still pending; latest published release is [v2.6.0](https://github.com/Kamra-PMS/kamra-pms/releases/tag/v2.6.0)) plus Unreleased work: cashier/finance, **85 MCP tools**, System Health, property time zone, and banquet Phase 1. Notes: [CHANGELOG](https://github.com/Kamra-PMS/kamra-pms/blob/develop/CHANGELOG.md).
 :::
 
 Kamra is a complete property-management system for hotels and short-term

--- a/docs/ai-and-api.md
+++ b/docs/ai-and-api.md
@@ -15,9 +15,9 @@ An optional chat assistant for staff, right inside the console.
 provider's API key, save. The sparkle button appears bottom-right for
 everyone at that property.
 
-- **Any OpenAI-compatible provider works** — OpenAI
-  (`https://api.openai.com/v1`), OpenRouter, Groq, a local Ollama/vLLM.
-  Set the base URL and model to taste.
+- **Any OpenAI-compatible provider works.** Settings presets cover
+  OpenAI, Gemini, Groq, OpenRouter, and Ollama (OpenAI-compatible base
+  URL + Test connection). Set the base URL and model to taste.
 - **Your key, your data.** Kamra adds no markup and proxies nothing
   through third parties — requests go from your server to your provider.
 - **Governed:** the model can only call Kamra's tools (quote, book,

--- a/docs/marketplace-listing.md
+++ b/docs/marketplace-listing.md
@@ -59,10 +59,11 @@ is pulled in automatically.
 
 ### What makes it different
 
-- **Agent-ready, not agent-locked.** An MCP server exposes 52 role-scoped
-  tools. Click Connect Claude — *"book Mr. Rao a deluxe for the
-  weekend with breakfast"* — it quotes, books, and logs every action. Bring
-  your own AI; there is no bundled model markup.
+- **Agent-ready, not agent-locked.** An MCP server exposes 85 role-scoped
+  tools, filtered by the property's enabled modules. Click Connect Claude —
+  *"book Mr. Rao a deluxe for the weekend with breakfast"* — it quotes,
+  books, and logs every action. Bring your own AI; there is no bundled
+  model markup.
 - **Deterministic money.** Prices, taxes and availability come from a
   pricing engine, never from a language model. Tax slabs, multi-rate
   invoices and the no-overbooking guard are code, verified by an eval suite
@@ -98,14 +99,15 @@ is pulled in automatically.
   enforced in code.
 - **Billing** — folios with per-line tax, corporate charge routing, group
   master folios, exact %/amount charge splits, automated night audit, tax
-  invoices with B2B fields, cashier reconciliation, payment links via
-  frappe/payments.
+  invoices with B2B fields, Opera-style cashier till (FO+POS cash, PIN
+  pad), append-only folio ledger, payment links via frappe/payments.
 - **Restaurant POS** — area-wise table map with live states, concurrent &
-  split bills, dine-in / room service / takeaway / delivery, 80mm thermal
-  KOT & bill printing, kitchen display, inventory & recipes, guest QR
-  ordering, room posting (alcohol-aware).
+  split bills, dine-in / room service / takeaway / delivery, full-screen
+  till and kitchen pass, 80mm thermal KOT & bill printing, kitchen display,
+  inventory & recipes, guest QR ordering, room posting (alcohol-aware).
 - **Operations** — service tickets with SLA, a housekeeping mobile app,
-  end-to-end guest laundry, lost & found, shift handover, venues & events.
+  end-to-end guest laundry, lost & found, shift handover, venues & events
+  (send quote, guest response, department checklists on Confirm).
 - **Guests** — self check-in with ID & address-proof capture, printable
   GRC with the legal occupant register, editable actual times, a stay
   ledger with advances/deposits/guarded refunds, retention-aware ID
@@ -118,9 +120,10 @@ is pulled in automatically.
   flat-tax generic for everywhere else; currency and number locale follow
   the pack.
 - **Platform** — multi-property with per-user scoping, six-role RBAC, dark
-  mode, onboarding wizard, CSV migration importers (eZee / Cloudbeds
-  presets), and a 51-check eval harness + 13-journey front-desk persona
-  suite in CI.
+  mode, property time zone, System Health diagnostics, AI provider presets
+  (OpenAI, Gemini, Groq, OpenRouter, Ollama), onboarding wizard, CSV
+  migration importers (eZee / Cloudbeds presets), and a 51-check eval
+  harness + 13-journey front-desk persona suite in CI.
 
 ### After install
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

README and the shared docs surface were behind `CHANGELOG.md` on `develop`: MCP still said 50+, Features missed System Health / property time zone / banquet Phase 1 / cashier, and there was no pointer to the current train.

## For Mohammed

- **Did not** merge Release Please [#68](https://github.com/Kamra-PMS/kamra-pms/pull/68).
- **Did not** treat 2.6.2 as published. Latest GitHub release is still [v2.6.0](https://github.com/Kamra-PMS/kamra-pms/releases/tag/v2.6.0). `__version__` is already `2.6.2` on `main`/`develop`, but there is no `v2.6.2` tag.
- **`CHANGELOG.md` left alone** — Release Please owns that file.

### README

- New **What's new** section: short pointer to Unreleased + 2.6.2 highlights, links to `CHANGELOG.md` / `RELEASING.md`, phrased as on develop / upcoming (not a second changelog).
- MCP **50+ → 85**, module-gated.
- Features: cashier / folio ledger, POS till, banquet Phase 1 (send quote + dept checklists), System Health, property time zone, AI presets. WordPress-easy install was already in Install.

### Companion docs (same surface only)

- `docs-site/index.md` — replaced the stale "Kamra 2.5 / STR" tip with a develop / 2.6.2 pointer.
- `docs-site/features.md` — cashier, banquet Phase 1, MCP module gates + presets, Admin (System Health / timezone), POS till.
- `docs/marketplace-listing.md` — MCP 52 → 85 and matching feature bullets. Publish-checklist SHAs still say v2.5.0 (left alone; that is FC process copy, not this train).
- `docs/ai-and-api.md` — Settings presets (OpenAI, Gemini, Groq, OpenRouter, Ollama).

## Checklist

- [x] PR targets **`develop`** (not `main`)
- [x] Title / commits follow Conventional Commits (`docs:`)
- [x] No frontend / Python (build + eval harness N/A)
- [x] Nothing removed/renamed for self-hosters

## Breaking changes

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8549d74-3be9-44ac-8181-deb64ef33200?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8549d74-3be9-44ac-8181-deb64ef33200&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

